### PR TITLE
Add debug mode to config flow

### DIFF
--- a/custom_components/localtuya/config_flow.py
+++ b/custom_components/localtuya/config_flow.py
@@ -244,7 +244,8 @@ class LocaltuyaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return await self.async_step_basic_info()
 
         # Use cache if available or fallback to manual discovery
-        if DOMAIN in self.hass.data:
+        data = self.hass.data.get(DOMAIN, {})
+        if DATA_DISCOVERY in data:
             devices = self.hass.data[DOMAIN][DATA_DISCOVERY].devices
         else:
             devices = await discover()
@@ -358,9 +359,7 @@ class LocaltuyaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     type_convert = DEBUG_TYPES_CONVERSIONS[user_input[CONF_DATA_TYPE]]
                     value = type_convert(user_input[CONF_VALUE])
                     dp = user_input[CONF_DATAPOINT].split(" ")[0]
-                    await _tuya_command(
-                        self.hass, self.basic_info, "set_dps", value, dp
-                    )
+                    await _tuya_command(self.hass, self.basic_info, "set_dp", value, dp)
                 except Exception:  # pylint: disable=broad-except
                     _LOGGER.exception(f"failed to set datapoint {dp}={value}")
                     errors["base"] = "set_dp_failed"

--- a/custom_components/localtuya/discovery.py
+++ b/custom_components/localtuya/discovery.py
@@ -55,8 +55,9 @@ class TuyaDiscovery(asyncio.DatagramProtocol):
     def close(self):
         """Stop discovery."""
         self.callback = None
-        for transport, _ in self.listeners:
-            transport.close()
+        if self._listeners is not None:
+            for transport, _ in self._listeners:
+                transport.close()
 
     def datagram_received(self, data, addr):
         """Handle received broadcast message."""

--- a/custom_components/localtuya/translations/en.json
+++ b/custom_components/localtuya/translations/en.json
@@ -1,13 +1,17 @@
 {
     "config": {
         "abort": {
-            "already_configured": "Device has already been configured."
+            "already_configured": "Device has already been configured.",
+            "exit_debug": "Leaving debug mode."
         },
         "error": {
             "cannot_connect": "Cannot connect to device. Verify that address is correct and try again.",
             "invalid_auth": "Failed to authenticate with device. Verify that device id and local key are correct.",
             "unknown": "An unknown error occurred. See log for details.",
-            "entity_already_configured": "Entity with this ID has already been configured."
+            "entity_already_configured": "Entity with this ID has already been configured.",
+            "discovery_failed": "Failed to discover devices. You can still add a device manually.",
+            "fetch_dps_failed": "Failed to fetch datapoints. See log for details.",
+            "set_dp_failed": "Failed to set datapoint. See log for details."
         },
         "step": {
             "user": {
@@ -25,7 +29,8 @@
                     "host": "Host",
                     "device_id": "Device ID",
                     "local_key": "Local key",
-                    "protocol_version": "Protocol Version"
+                    "protocol_version": "Protocol Version",
+                    "debug": "Enable debug mode"
                 }
             },
             "pick_entity_type": {
@@ -60,6 +65,16 @@
                     "brightness_lower": "Brightness Lower Value",
                     "brightness_upper": "Brightness Upper Value",
                     "color_temp": "Color Temperature"
+                }
+            },
+            "debug": {
+                "title": "Debug",
+                "description": "You can manually alter the value of a datapoint here. Current values for all datapoints:\n\n{dps}",
+                "data": {
+                    "action": "Action",
+                    "datapoint": "Datapoint",
+                    "data_type": "Data Type",
+                    "value": "Value"
                 }
             }
         }


### PR DESCRIPTION
This PR adds a "debug mode" to the config flow. When filling in the basic info, if ticking the "Enable debug mode", the following step is presented:

![DDF01DC9-F0D7-45FD-B2F5-C229B04B479A](https://user-images.githubusercontent.com/5982179/95895587-2eb28a00-0d8b-11eb-913d-0cac6605540e.png)

From here datapoints can be changed to arbitrary values (assuming supported), so it's great to try things out. It also displays current values of all datapoints in text to make it easier to copy.

Albeit, not my finest work... I think this will be pretty great when we ask for help from our users. Thoughts?