### PR TITLE
Add support for passive devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,25 @@ Energy monitoring (voltage, current...) values can be obtained in two different 
                unit_of_measurement: 'W' 
 ```   
 
+# Passive Devices
+
+Some battery powered devices, like window and door sensors, will go to sleep as much as posssible to save
+battery. This is problematic as it's not possible to maintain a persistent connection, nor connect
+at all. To support these kinds of devices, `localtuya` has a concept of *passive devices*. When a device is
+configured as passive, `localtuya` will not actively try to maintain a connection or re-connect upon errors.
+Instead, `localtuya` monitors broadcast messages sent by devices to announce their prescence on the network.
+Once such a broadcast has been received, a connection is made and state updated. When a passive device goes to
+sleep, all entities belonging to it will maintain their previous states (instead of becoming unavailable).
+The state is even restored between restarts of Home Assistant.
+
+There is currently no "timeout" detection, e.g. changing of state because no connection has been made in a
+while. Entities of a passive device that is disconnected will get the "last_seen" state attribute. It will
+indicate when a connection was last established and can be used to monitor an entity externally (e.g. using
+an automation).
+
+To configure a device as passive with config flow, check the box `Set up as a passive device`. In YAML, set
+`passive_device` to `true`.
+
 # Debugging
 
 Whenever you write a bug report, it helps tremendously if you include debug logs directly (otherwise we will just ask for them and it will take longer). So please enable debug logs like this and include them in your issue:

--- a/custom_components/localtuya/__init__.py
+++ b/custom_components/localtuya/__init__.py
@@ -9,6 +9,7 @@ localtuya:
     local_key: xxxxx
     friendly_name: Tuya Device
     protocol_version: "3.3"
+    passive_device: "false" # Optional, default "false"
     entities:
       - platform: binary_sensor
         friendly_name: Plug Status
@@ -156,10 +157,12 @@ async def async_setup(hass: HomeAssistant, config: dict):
 
         # If device is passive, initiate connection attempt
         if entry.data[CONF_PASSIVE_DEVICE]:
-            _LOGGER.debug("Passive device %s found with IP %s", device_id, device_ip)
-
             device = hass.data[DOMAIN][entry.entry_id][TUYA_DEVICE]
-            device.connect()
+            if not device.connected:
+                _LOGGER.debug(
+                    "Passive device %s found with IP %s", device_id, device_ip
+                )
+                device.connect()
 
     discovery = TuyaDiscovery(_device_discovered)
 
@@ -209,7 +212,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
                 for platform in platforms
             ]
         )
-        if not entry.data[CONF_PASSIVE_DEVICE]:
+        if not entry.data.get(CONF_PASSIVE_DEVICE):
             device.connect()
         else:
             _LOGGER.debug(

--- a/custom_components/localtuya/common.py
+++ b/custom_components/localtuya/common.py
@@ -19,7 +19,13 @@ from homeassistant.helpers.dispatcher import (
 from homeassistant.helpers.entity import Entity
 
 from . import pytuya
-from .const import CONF_LOCAL_KEY, CONF_PROTOCOL_VERSION, DOMAIN, TUYA_DEVICE
+from .const import (
+    CONF_LOCAL_KEY,
+    CONF_PROTOCOL_VERSION,
+    CONF_PASSIVE_DEVICE,
+    DOMAIN,
+    TUYA_DEVICE,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -201,7 +207,10 @@ class TuyaDevice(pytuya.TuyaListener):
         async_dispatcher_send(self._hass, signal, None)
 
         self._interface = None
-        self.connect()
+        if not self._config_entry[CONF_PASSIVE_DEVICE]:
+            self.connect()
+        else:
+            _LOGGER.debug("No automatic re-connect due to passive device")
 
 
 class LocalTuyaEntity(Entity):

--- a/custom_components/localtuya/config_flow.py
+++ b/custom_components/localtuya/config_flow.py
@@ -17,10 +17,10 @@ from homeassistant.core import callback
 
 from . import pytuya
 from .const import (  # pylint: disable=unused-import
-    CONF_LOCAL_KEY,
-    CONF_PROTOCOL_VERSION,
     CONF_DPS_STRINGS,
+    CONF_LOCAL_KEY,
     CONF_PASSIVE_DEVICE,
+    CONF_PROTOCOL_VERSION,
     DATA_DISCOVERY,
     DOMAIN,
     PLATFORMS,
@@ -52,6 +52,7 @@ OPTIONS_SCHEMA = vol.Schema(
         vol.Required(CONF_HOST): str,
         vol.Required(CONF_LOCAL_KEY): str,
         vol.Required(CONF_PROTOCOL_VERSION, default="3.3"): vol.In(["3.1", "3.3"]),
+        vol.Required(CONF_PASSIVE_DEVICE, default=False): bool,
     }
 )
 

--- a/custom_components/localtuya/config_flow.py
+++ b/custom_components/localtuya/config_flow.py
@@ -17,9 +17,10 @@ from homeassistant.core import callback
 
 from . import pytuya
 from .const import (  # pylint: disable=unused-import
-    CONF_DPS_STRINGS,
     CONF_LOCAL_KEY,
     CONF_PROTOCOL_VERSION,
+    CONF_DPS_STRINGS,
+    CONF_PASSIVE_DEVICE,
     DATA_DISCOVERY,
     DOMAIN,
     PLATFORMS,
@@ -41,6 +42,7 @@ BASIC_INFO_SCHEMA = vol.Schema(
         vol.Required(CONF_HOST): str,
         vol.Required(CONF_DEVICE_ID): str,
         vol.Required(CONF_PROTOCOL_VERSION, default="3.3"): vol.In(["3.1", "3.3"]),
+        vol.Required(CONF_PASSIVE_DEVICE, default=False): bool,
     }
 )
 
@@ -60,6 +62,7 @@ DEVICE_SCHEMA = vol.Schema(
         vol.Required(CONF_LOCAL_KEY): cv.string,
         vol.Required(CONF_FRIENDLY_NAME): cv.string,
         vol.Required(CONF_PROTOCOL_VERSION, default="3.3"): vol.In(["3.1", "3.3"]),
+        vol.Required(CONF_PASSIVE_DEVICE, default=False): bool,
     }
 )
 

--- a/custom_components/localtuya/const.py
+++ b/custom_components/localtuya/const.py
@@ -1,5 +1,7 @@
 """Constants for localtuya integration."""
 
+ATTR_LAST_SEEN = "last_seen"
+ATTR_OLD_STATE = "old_state"
 ATTR_CURRENT = "current"
 ATTR_CURRENT_CONSUMPTION = "current_consumption"
 ATTR_VOLTAGE = "voltage"

--- a/custom_components/localtuya/const.py
+++ b/custom_components/localtuya/const.py
@@ -7,6 +7,7 @@ ATTR_VOLTAGE = "voltage"
 CONF_LOCAL_KEY = "local_key"
 CONF_PROTOCOL_VERSION = "protocol_version"
 CONF_DPS_STRINGS = "dps_strings"
+CONF_PASSIVE_DEVICE = "passive_device"
 
 # light
 CONF_BRIGHTNESS_LOWER = "brightness_lower"

--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -10,8 +10,8 @@ from homeassistant.components.light import (
     ATTR_HS_COLOR,
     DOMAIN,
     SUPPORT_BRIGHTNESS,
-    SUPPORT_COLOR_TEMP,
     SUPPORT_COLOR,
+    SUPPORT_COLOR_TEMP,
     LightEntity,
 )
 from homeassistant.const import CONF_BRIGHTNESS, CONF_COLOR_TEMP

--- a/custom_components/localtuya/switch.py
+++ b/custom_components/localtuya/switch.py
@@ -50,7 +50,7 @@ class LocaltuyaSwitch(LocalTuyaEntity, SwitchEntity):
     @property
     def device_state_attributes(self):
         """Return device state attributes."""
-        attrs = {}
+        attrs = super().device_state_attributes
         if self.has_config(CONF_CURRENT):
             attrs[ATTR_CURRENT] = self.dps(self._config[CONF_CURRENT])
         if self.has_config(CONF_CURRENT_CONSUMPTION):

--- a/custom_components/localtuya/translations/en.json
+++ b/custom_components/localtuya/translations/en.json
@@ -25,7 +25,8 @@
                     "host": "Host",
                     "device_id": "Device ID",
                     "local_key": "Local key",
-                    "protocol_version": "Protocol Version"
+                    "protocol_version": "Protocol Version",
+                    "passive_device": "Set up as a passive device"
                 }
             },
             "pick_entity_type": {
@@ -75,7 +76,8 @@
                     "friendly_name": "Friendly Name",
                     "host": "Host",
                     "local_key": "Local key",
-                    "protocol_version": "Protocol Version"
+                    "protocol_version": "Protocol Version",
+                    "passive_device": "Set up as a passive device"
                 }
             },
             "entity": {


### PR DESCRIPTION
This PR introduces the concept of "passive devices". When adding a device and making it passive (it's a box in the config flow or `passive_device` in YAML), no connection (or re-connection) attempts will be made to the device automatically. This is totally driven by broadcast messages from devices. Once a broadcast message has been received from a passive device, a connection will be established. In theory this could be default, but there are circumstances where this probably won't work. So leaving it as opt-in.

One excellent use case for this is devices that just wake up, phone home and go to sleep again, e.g. battery powered devices. This has been reported in #89. It's worth noting that I don't actually know if this works or not, I just hope it does.

NB: This PR builds on top of #86. So those commits must be removed before merging.