### PR TITLE
Add hsv color support

### DIFF
--- a/custom_components/localtuya/const.py
+++ b/custom_components/localtuya/const.py
@@ -11,6 +11,10 @@ CONF_DPS_STRINGS = "dps_strings"
 # light
 CONF_BRIGHTNESS_LOWER = "brightness_lower"
 CONF_BRIGHTNESS_UPPER = "brightness_upper"
+CONF_COLOR_TEMP_LOWER = "color_temp_lower"
+CONF_COLOR_TEMP_UPPER = "color_temp_upper"
+CONF_HS_COLOR = "hs_color"
+CONF_LIGHT_MODE = "light_mode"
 
 # switch
 CONF_CURRENT = "current"

--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -10,20 +10,26 @@ from homeassistant.components.light import (
     DOMAIN,
     SUPPORT_BRIGHTNESS,
     SUPPORT_COLOR_TEMP,
+    SUPPORT_COLOR,
     LightEntity,
 )
 from homeassistant.const import CONF_BRIGHTNESS, CONF_COLOR_TEMP
 
 from .common import LocalTuyaEntity, async_setup_entry
-from .const import CONF_BRIGHTNESS_LOWER, CONF_BRIGHTNESS_UPPER
+from .const import CONF_BRIGHTNESS_LOWER, CONF_BRIGHTNESS_UPPER, CONF_COLOR_TEMP_LOWER, CONF_COLOR_TEMP_UPPER, CONF_HS_COLOR, CONF_LIGHT_MODE
 
 _LOGGER = logging.getLogger(__name__)
 
 MIN_MIRED = 153
-MAX_MIRED = 370
+MAX_MIRED = 500
+
+DEFAULT_LOWER_COLOR_TEMP = 0
+DEFAULT_UPPER_COLOR_TEMP = 1000
 
 DEFAULT_LOWER_BRIGHTNESS = 29
 DEFAULT_UPPER_BRIGHTNESS = 1000
+
+LIGHT_MODES = ["white","colour","scene","music"]
 
 
 def map_range(value, from_lower, from_upper, to_lower, to_upper):
@@ -33,16 +39,29 @@ def map_range(value, from_lower, from_upper, to_lower, to_upper):
     ) + to_lower
     return round(min(max(mapped, to_lower), to_upper))
 
+def map_range_inverted(value, from_lower, from_upper, to_lower, to_upper):
+    """Map a value in one range to another (inverted)."""
+    mapped = map_range(value, from_lower, from_upper, to_lower, to_upper)
+    inverted = to_lower + (to_upper - mapped)
+    return inverted
 
 def flow_schema(dps):
     """Return schema used in config flow."""
     return {
+        vol.Optional(CONF_LIGHT_MODE): vol.In(dps),
         vol.Optional(CONF_BRIGHTNESS): vol.In(dps),
         vol.Optional(CONF_COLOR_TEMP): vol.In(dps),
+        vol.Optional(CONF_HS_COLOR): vol.In(dps),
         vol.Optional(CONF_BRIGHTNESS_LOWER, default=DEFAULT_LOWER_BRIGHTNESS): vol.All(
             vol.Coerce(int), vol.Range(min=0, max=10000)
         ),
         vol.Optional(CONF_BRIGHTNESS_UPPER, default=DEFAULT_UPPER_BRIGHTNESS): vol.All(
+            vol.Coerce(int), vol.Range(min=0, max=10000)
+        ),
+        vol.Optional(CONF_COLOR_TEMP_LOWER, default=DEFAULT_LOWER_COLOR_TEMP): vol.All(
+            vol.Coerce(int), vol.Range(min=0, max=10000)
+        ),
+        vol.Optional(CONF_COLOR_TEMP_UPPER, default=DEFAULT_UPPER_COLOR_TEMP): vol.All(
             vol.Coerce(int), vol.Range(min=0, max=10000)
         ),
     }
@@ -63,11 +82,19 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
         self._state = False
         self._brightness = None
         self._color_temp = None
+        self._hs_color = None
+        self._light_mode = None
         self._lower_brightness = self._config.get(
             CONF_BRIGHTNESS_LOWER, DEFAULT_LOWER_BRIGHTNESS
         )
         self._upper_brightness = self._config.get(
             CONF_BRIGHTNESS_UPPER, DEFAULT_UPPER_BRIGHTNESS
+        )
+        self._lower_color_temp = self._config.get(
+            CONF_COLOR_TEMP_LOWER, DEFAULT_LOWER_COLOR_TEMP
+        )
+        self._upper_color_temp = self._config.get(
+            CONF_COLOR_TEMP_UPPER, DEFAULT_UPPER_COLOR_TEMP
         )
 
     @property
@@ -84,7 +111,21 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
     def color_temp(self):
         """Return the color_temp of the light."""
         if self.has_config(CONF_COLOR_TEMP):
-            return int(MAX_MIRED - (((MAX_MIRED - MIN_MIRED) / 255) * self._color_temp))
+            return self._color_temp
+        return None
+    
+    @property
+    def hs_color(self):
+        """Return the color of the light."""
+        if self.has_config(CONF_HS_COLOR):
+            return self._hs_color
+        return None
+    
+    @property
+    def light_mode(self):
+        """Return the mode of the light."""
+        if self.has_config(CONF_LIGHT_MODE):
+            return self._light_mode
         return None
 
     @property
@@ -105,7 +146,50 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
             supports |= SUPPORT_BRIGHTNESS
         if self.has_config(CONF_COLOR_TEMP):
             supports |= SUPPORT_COLOR_TEMP
+        if self.has_config(CONF_HS_COLOR):
+            supports |= SUPPORT_COLOR
         return supports
+    
+    def tuya_hsv_to_hsv(self, hs_color):
+        """Convert from tuya hsv format to HA hs + v format"""
+        if hs_color is not None:
+            h = float(int(hs_color[0:4], 16))
+            s = float(map_range(
+                    int(hs_color[4:8], 16),
+                    0,
+                    1000,
+                    0,
+                    100,
+                ))
+            v = float(map_range(
+                    int(hs_color[8:], 16),
+                    self._lower_brightness,
+                    self._upper_brightness,
+                    0,
+                    255,
+                ))
+            return (h, s, v)
+        return None
+
+    def hsv_to_tuya_hsv(self, hs_color):
+        """Convert from HA hs + v format to tuya hsv format"""
+        if hs_color is not None:
+            h = int(hs_color[0])
+            s = map_range(
+                int(hs_color[1]),
+                0,
+                100,
+                0,
+                1000)
+            v = map_range(
+                int(hs_color[2]),
+                0,
+                255,
+                self._lower_brightness,
+                self._upper_brightness
+            )
+            return f'{h:0>4X}' + f'{s:0>4X}' + f'{v:0>4X}'
+        return None
 
     async def async_turn_on(self, **kwargs):
         """Turn on or control the light."""
@@ -120,16 +204,28 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
                 self._lower_brightness,
                 self._upper_brightness,
             )
-            await self._device.set_dp(brightness, self._config.get(CONF_BRIGHTNESS))
+            if self.light_mode == LIGHT_MODES[1]:
+                hs_color = self.hs_color
+                hs_color = (hs_color[0], hs_color[1], int(kwargs[ATTR_BRIGHTNESS]))
+                hs_color = self.hsv_to_tuya_hsv(hs_color)
+                await self._device.set_dp(hs_color, self._config.get(CONF_HS_COLOR))
+            else:
+                await self._device.set_dp(brightness, self._config.get(CONF_BRIGHTNESS))
 
-        if ATTR_HS_COLOR in kwargs:
-            raise ValueError(" TODO implement RGB from HS")
+        if ATTR_HS_COLOR in kwargs and (features & SUPPORT_COLOR):
+            hs_color = (kwargs[ATTR_HS_COLOR][0], kwargs[ATTR_HS_COLOR][1], self.brightness)
+            hs_color = self.hsv_to_tuya_hsv(hs_color)
+            if self.light_mode != LIGHT_MODES[1]:
+                await self._device.set_dp(LIGHT_MODES[1], self._config.get(CONF_LIGHT_MODE))
+            await self._device.set_dp(hs_color, self._config.get(CONF_HS_COLOR))
 
         if ATTR_COLOR_TEMP in kwargs and (features & SUPPORT_COLOR_TEMP):
-            color_temp = int(
-                255
-                - (255 / (MAX_MIRED - MIN_MIRED))
-                * (int(kwargs[ATTR_COLOR_TEMP]) - MIN_MIRED)
+            color_temp = map_range_inverted(
+                int(kwargs[ATTR_COLOR_TEMP]),
+                MIN_MIRED,
+                MAX_MIRED,
+                self._lower_color_temp,
+                self._upper_color_temp,
             )
             await self._device.set_dp(color_temp, self._config.get(CONF_COLOR_TEMP))
 
@@ -142,8 +238,25 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
         self._state = self.dps(self._dp_id)
         supported = self.supported_features
 
+        # Get the current light mode
+        if supported & self.has_config(CONF_LIGHT_MODE):
+            light_mode = self.dps_conf(CONF_LIGHT_MODE)
+            self._light_mode = light_mode
+
+        # Get the current color
+        if supported & SUPPORT_COLOR:
+            hsv_color = self.dps_conf(CONF_HS_COLOR)
+            if hsv_color is not None:
+                hsv_color = self.tuya_hsv_to_hsv(hsv_color)
+            self._hs_color = (hsv_color[0], hsv_color[1])
+
+        # Get the current brightness
         if supported & SUPPORT_BRIGHTNESS:
-            brightness = self.dps_conf(CONF_BRIGHTNESS)
+            if self.light_mode != LIGHT_MODES[1]:  # If not color mode
+                brightness = self.dps_conf(CONF_BRIGHTNESS)
+            elif self.light_mode == LIGHT_MODES[1]:  # If color mode
+                hsv_color = self.dps_conf(CONF_HS_COLOR)
+                brightness = int(hsv_color[8:], 16)
             if brightness is not None:
                 brightness = map_range(
                     brightness,
@@ -154,8 +267,18 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
                 )
             self._brightness = brightness
 
+        # Get the current color temp
         if supported & SUPPORT_COLOR_TEMP:
-            self._color_temp = self.dps_conf(CONF_COLOR_TEMP)
+            color_temp = self.dps_conf(CONF_COLOR_TEMP)
+            if color_temp is not None:
+                color_temp = map_range_inverted(
+                    color_temp,
+                    self._lower_color_temp,
+                    self._upper_color_temp,
+                    MIN_MIRED,
+                    MAX_MIRED,
+                )
+            self._color_temp = color_temp
 
 
 async_setup_entry = partial(async_setup_entry, DOMAIN, LocaltuyaLight, flow_schema)

--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -227,6 +227,8 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
                 self._lower_color_temp,
                 self._upper_color_temp,
             )
+            if self.light_mode != LIGHT_MODES[0]:  #If not white mode
+                await self._device.set_dp(LIGHT_MODES[0], self._config.get(CONF_LIGHT_MODE))
             await self._device.set_dp(color_temp, self._config.get(CONF_COLOR_TEMP))
 
     async def async_turn_off(self, **kwargs):

--- a/custom_components/localtuya/translations/en.json
+++ b/custom_components/localtuya/translations/en.json
@@ -59,7 +59,11 @@
                     "brightness": "Brightness",
                     "brightness_lower": "Brightness Lower Value",
                     "brightness_upper": "Brightness Upper Value",
-                    "color_temp": "Color Temperature"
+                    "color_temp": "Color Temperature",
+                    "color_temp_lower": "Color Temperature Lower Value",
+                    "color_temp_upper": "Color Temperature Upper Value",
+                    "hs_color": "Color",
+                    "light_mode": "Light Mode"
                 }
             }
         }
@@ -99,7 +103,11 @@
                     "brightness": "Brightness",
                     "brightness_lower": "Brightness Lower Value",
                     "brightness_upper": "Brightness Upper Value",
-                    "color_temp": "Color Temperature"
+                    "color_temp": "Color Temperature",
+                    "color_temp_lower": "Color Temperature Lower Value",
+                    "color_temp_upper": "Color Temperature Upper Value",
+                    "hs_color": "Color",
+                    "light_mode": "Light Mode"
                 }
             },
             "yaml_import": {


### PR DESCRIPTION
This PR adds:

1) Hsv color support
2) Color brightness (workaround)
2) Improved color temperature handling

The color brightness workaround has been done to compensate for the the inability of Tuya bulbs to use the normal brightness DP when in color mode. For this reason when the light bulb is in color mode, the Volume value in the HSV tuple is used instead. The one downside I could not solve is that since the brightness handling is different, when switching from white to color, the brightness level is not preserved. Anyhow once it is switched to either mode, the brightness control works as expected.