### PR TITLE
Add support of RGB lights

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,16 @@ localtuya:
 
       - platform: light
         friendly_name: Device Light
-        id: 4
+        id: 4 # Usually 1 or 20
+        color_mode: 21 # Optional, usually 2 or 21, default: "none"
+        brightness: 22 # Optional, usually 3 or 22, default: "none"
+        color_temp: 23 # Optional, usually 4 or 23, default: "none"
+        color: 24 # Optional, usually 5 (RGB_HSV) or 24(HSV), default: "none"
+        brightness_lower: 29 # Optional, usually 0 or 29, default: 29
+        brightness_upper: 1000 # Optional, usually 255 or 1000, default: 1000
+        color_temp_min_kelvin: 2700 # Optional, default: 2700
+        color_temp_max_kelvin: 6500 # Optional, default: 6500
+
 
       - platform: sensor
         friendly_name: Plug Voltage

--- a/custom_components/localtuya/common.py
+++ b/custom_components/localtuya/common.py
@@ -182,6 +182,18 @@ class TuyaDevice(pytuya.TuyaListener):
                 "Not connected to device %s", self._config_entry[CONF_FRIENDLY_NAME]
             )
 
+    async def set_dps(self, states):
+        """Change value of a DPs of the Tuya device."""
+        if self._interface is not None:
+            try:
+                await self._interface.set_dps(states)
+            except Exception:
+                _LOGGER.exception("Failed to set DPs %r", states)
+        else:
+            _LOGGER.error(
+                "Not connected to device %s", self._config_entry[CONF_FRIENDLY_NAME]
+            )
+
     @callback
     def status_updated(self, status):
         """Device updated status."""

--- a/custom_components/localtuya/const.py
+++ b/custom_components/localtuya/const.py
@@ -13,6 +13,8 @@ CONF_BRIGHTNESS_LOWER = "brightness_lower"
 CONF_BRIGHTNESS_UPPER = "brightness_upper"
 CONF_COLOR = "color"
 CONF_COLOR_MODE = "color_mode"
+CONF_COLOR_TEMP_MIN_KELVIN = "color_temp_min_kelvin"
+CONF_COLOR_TEMP_MAX_KELVIN = "color_temp_max_kelvin"
 
 # switch
 CONF_CURRENT = "current"

--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -254,7 +254,9 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
                     self._hs = [hue, (sat * 100 / 255)]
                     self._brightness = value
                 else:
-                    hue, sat, value = [int(value, 16) for value in textwrap.wrap(color, 4)]
+                    hue, sat, value = [
+                        int(value, 16) for value in textwrap.wrap(color, 4)
+                    ]
                     self._hs = [hue, sat / 10.0]
                     self._brightness = value
 

--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -96,12 +96,13 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
         self._min_mired = round(
             MIRED_TO_KELVIN_CONST
             / self._config.get(CONF_COLOR_TEMP_MAX_KELVIN, DEFAULT_MAX_KELVIN)
-        )        
+        )
         self._is_white_mode = True  # Hopefully sane default
         self._hs = None
         self._is_rgb_mode = (
             True if self._upper_brightness != DEFAULT_UPPER_BRIGHTNESS else False
         )
+
     @property
     def is_on(self):
         """Check if Tuya light is on."""

--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -239,7 +239,7 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
         if supported & SUPPORT_COLOR:
             self._is_white_mode = self.dps_conf(CONF_COLOR_MODE) == "white"
             if self._is_white_mode:
-                self._hs = None
+                self._hs = [0, 0]
 
         if self._is_white_mode:
             if supported & SUPPORT_BRIGHTNESS:

--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -152,7 +152,7 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
             supports |= SUPPORT_COLOR | SUPPORT_BRIGHTNESS
         return supports
 
-    def is_color_rgb_encoded(self):
+    def __is_color_rgb_encoded(self):
         return len(self.dps_conf(CONF_COLOR)) > 12
 
     async def async_turn_on(self, **kwargs):
@@ -172,7 +172,7 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
                 states[self._config.get(CONF_BRIGHTNESS)] = brightness
 
             else:
-                if self.is_color_rgb_encoded():
+                if self.__is_color_rgb_encoded():
                     rgb = color_util.color_hsv_to_RGB(
                         self._hs[0],
                         self._hs[1],
@@ -194,7 +194,7 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
 
         if ATTR_HS_COLOR in kwargs and (features & SUPPORT_COLOR):
             hs = kwargs[ATTR_HS_COLOR]
-            if self.is_color_rgb_encoded():
+            if self.__is_color_rgb_encoded():
                 rgb = color_util.color_hsv_to_RGB(
                     hs[0], hs[1], int(self._brightness * 100 / self._upper_brightness)
                 )
@@ -246,7 +246,7 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
                 self._brightness = self.dps_conf(CONF_BRIGHTNESS)
         else:
             color = self.dps_conf(CONF_COLOR)
-            if self.is_color_rgb_encoded():
+            if self.__is_color_rgb_encoded():
                 hue = int(color[6:10], 16)
                 sat = int(color[10:12], 16)
                 value = int(color[12:14], 16)

--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -246,16 +246,17 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
                 self._brightness = self.dps_conf(CONF_BRIGHTNESS)
         else:
             color = self.dps_conf(CONF_COLOR)
-            if self.__is_color_rgb_encoded():
-                hue = int(color[6:10], 16)
-                sat = int(color[10:12], 16)
-                value = int(color[12:14], 16)
-                self._hs = [hue, (sat * 100 / 255)]
-                self._brightness = value
-            else:
-                hue, sat, value = [int(value, 16) for value in textwrap.wrap(color, 4)]
-                self._hs = [hue, sat / 10.0]
-                self._brightness = value
+            if color is not None:
+                if self.__is_color_rgb_encoded():
+                    hue = int(color[6:10], 16)
+                    sat = int(color[10:12], 16)
+                    value = int(color[12:14], 16)
+                    self._hs = [hue, (sat * 100 / 255)]
+                    self._brightness = value
+                else:
+                    hue, sat, value = [int(value, 16) for value in textwrap.wrap(color, 4)]
+                    self._hs = [hue, sat / 10.0]
+                    self._brightness = value
 
         if supported & SUPPORT_COLOR_TEMP:
             self._color_temp = self.dps_conf(CONF_COLOR_TEMP)

--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -99,9 +99,7 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
         )
         self._is_white_mode = True  # Hopefully sane default
         self._hs = None
-        self._is_rgb_mode = (
-            True if self._upper_brightness != DEFAULT_UPPER_BRIGHTNESS else False
-        )
+        self._is_rgb_mode = None
 
     @property
     def is_on(self):
@@ -194,6 +192,9 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
 
         if ATTR_HS_COLOR in kwargs and (features & SUPPORT_COLOR):
             hs = kwargs[ATTR_HS_COLOR]
+            if self._is_rgb_mode is None:
+                self._is_rgb_mode = len(self.dps_conf(CONF_COLOR)) > 12
+
             if self._is_rgb_mode:
                 rgb = color_util.color_hsv_to_RGB(
                     hs[0], hs[1], int(self._brightness * 100 / self._upper_brightness)

--- a/custom_components/localtuya/pytuya/__init__.py
+++ b/custom_components/localtuya/pytuya/__init__.py
@@ -444,7 +444,7 @@ class TuyaProtocol(asyncio.Protocol):
         """
         return await self.exchange(SET, {str(dp_index): value})
 
-    async def set_dps(self, value, dps):
+    async def set_dps(self, dps):
         """Set values for a set of datapoints."""
         return await self.exchange(SET, dps)
 

--- a/custom_components/localtuya/translations/en.json
+++ b/custom_components/localtuya/translations/en.json
@@ -61,7 +61,9 @@
                     "brightness_upper": "Brightness Upper Value",
                     "color_temp": "Color Temperature",
                     "color": "Color",
-                    "color_mode": "Color Mode"
+                    "color_mode": "Color Mode",
+                    "color_temp_min_kelvin": "Minimum Color Temperature in K",
+                    "color_temp_max_kelvin": "Maximum Color Temperature in K"
                 }
             }
         }
@@ -103,7 +105,9 @@
                     "brightness_upper": "Brightness Upper Value",
                     "color_temp": "Color Temperature",
                     "color": "Color",
-                    "color_mode": "Color Mode"
+                    "color_mode": "Color Mode",
+                    "color_temp_min_kelvin": "Minimum Color Temperature in K",
+                    "color_temp_max_kelvin": "Maximum Color Temperature in K"
                 }
             },
             "yaml_import": {


### PR DESCRIPTION
This PR contains:

- RGB Support
- Brightness consistency between color and white modes
- Optional color temperature range
- Use of single call to update multiple data points, reducing latency

I didn't add an option to configure the color_temp upper value as for all the bulbs i have, they are always in sync with the brightness max values.

Configuration is explained in the README
```yaml
      - platform: light
        friendly_name: Device Light
        id: 4 # Usually 1 or 20
        color_mode: 21 # Optional, usually 2 or 21, default: "none"
        brightness: 22 # Optional, usually 3 or 22, default: "none"
        color_temp: 23 # Optional, usually 4 or 23, default: "none"
        color: 24 # Optional, usually 5 (RGB_HSV) or 24(HSV), default: "none"
        brightness_lower: 29 # Optional, usually 0 or 29, default: 29
        # for brightness_upper from our current knowledge, 
        # bulb using id (1-5) should be set to 255, bulb using id (1-5) should be set to 1000. 
        brightness_upper: 1000 # Optional, usually 255 or 1000, default: 1000
        color_temp_min_kelvin: 2700 # Optional, default: 2700
        color_temp_max_kelvin: 6500 # Optional, default: 6500
```