### PR TITLE
Fix default scale factor preventing use of String sensors

### DIFF
--- a/custom_components/localtuya/sensor.py
+++ b/custom_components/localtuya/sensor.py
@@ -15,7 +15,6 @@ from .const import CONF_SCALING
 
 _LOGGER = logging.getLogger(__name__)
 
-DEFAULT_SCALING = 1.0
 DEFAULT_PRECISION = 2
 
 
@@ -24,7 +23,7 @@ def flow_schema(dps):
     return {
         vol.Optional(CONF_UNIT_OF_MEASUREMENT): str,
         vol.Optional(CONF_DEVICE_CLASS): vol.In(DEVICE_CLASSES),
-        vol.Optional(CONF_SCALING, default=DEFAULT_SCALING): vol.All(
+        vol.Optional(CONF_SCALING): vol.All(
             vol.Coerce(float), vol.Range(min=-1000000.0, max=1000000.0)
         ),
     }


### PR DESCRIPTION
Removed defalut scale factor of 1.0. 
The code is already applying the scale only if defined. Having a default value prevents using String sensor as it tries to apply the scale.

Should fix [issue 135](https://github.com/rospogrigio/localtuya/issues/135).