### PR TITLE
Scene support for lights.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The following Tuya device types are currently supported:
 * Fans
 * Climates (soon)
 
-Energy monitoring (voltage, current, watts, etc.) is supported for compatible devices. 
+Energy monitoring (voltage, current, watts, etc.) is supported for compatible devices.
 
 This repository's development has substantially started by utilizing and merging code from NameLessJedi, mileperhour and TradeFace, and then was deeply refactored to provide proper integration with Home Assistant environment, adding config flow and other features. Refer to the "Thanks to" section below.
 
@@ -56,7 +56,7 @@ localtuya:
         currpos_dps: 3 # Optional, required only for "position" mode
         setpos_dps: 4  # Optional, required only for "position" mode
         span_time: 25  # Full movement time: Optional, required only for "fake" mode
-        
+
       - platform: fan
         friendly_name: Device Fan
         id: 3
@@ -67,11 +67,13 @@ localtuya:
         color_mode: 21 # Optional, usually 2 or 21, default: "none"
         brightness: 22 # Optional, usually 3 or 22, default: "none"
         color_temp: 23 # Optional, usually 4 or 23, default: "none"
-        color: 24 # Optional, usually 5 (RGB_HSV) or 24(HSV), default: "none"
+        color: 24 # Optional, usually 5 (RGB_HSV) or 24 (HSV), default: "none"
         brightness_lower: 29 # Optional, usually 0 or 29, default: 29
         brightness_upper: 1000 # Optional, usually 255 or 1000, default: 1000
         color_temp_min_kelvin: 2700 # Optional, default: 2700
         color_temp_max_kelvin: 6500 # Optional, default: 6500
+        scene: 25 # Optional, usually 6 (RGB_HSV) or 25 (HSV), default: "none"
+        music_mode: False # Optional, some use internal mic, others, phone mic. Only internal mic is supported, default: "False"
 
 
       - platform: sensor
@@ -88,7 +90,7 @@ localtuya:
         current_consumption: 19 # Optional
         voltage: 20 # Optional
 ```
-   
+
 Note that a single device can contain several different entities. Some examples:
 - a cover device might have 1 (or many) cover entities, plus a switch to control backlight
 - a multi-gang switch will contain several switch entities, one for each gang controlled
@@ -98,12 +100,12 @@ Restart Home Assistant when finished editing.
 # 2. Using config flow
 
 Start by going to Configuration - Integration and pressing the "+" button to create a new Integration, then select LocalTuya in the drop-down menu.
-Wait for 6 seconds for the scanning of the devices in your LAN. Then, a drop-down menu will appear containing the list of detectes devices: you can 
+Wait for 6 seconds for the scanning of the devices in your LAN. Then, a drop-down menu will appear containing the list of detectes devices: you can
 select one of these, or manually input all the parameters.
 
 ![discovery](https://github.com/rospogrigio/localtuya-homeassistant/blob/master/img/1-discovery.png)
 
-If you have selected one entry, you just have to input the Friendly Name of the Device, and the localKey. 
+If you have selected one entry, you just have to input the Friendly Name of the Device, and the localKey.
 Once you press "Submit", the connection will be tested to check that everything works, in order to proceed.
 
 ![device](https://github.com/rospogrigio/localtuya-homeassistant/blob/master/img/2-device.png)
@@ -113,8 +115,8 @@ After you have defined all the needed entities leave the "Do not add more entiti
 
 ![entity_type](https://github.com/rospogrigio/localtuya-homeassistant/blob/master/img/3-entity_type.png)
 
-For each entity, the associated DP has to be selected. All the options requiring to select a DP will provide a drop-down menu showing 
-all the avaliable DPs found on the device (with their current status!!) for an easy identification. Each entity type has different options 
+For each entity, the associated DP has to be selected. All the options requiring to select a DP will provide a drop-down menu showing
+all the avaliable DPs found on the device (with their current status!!) for an easy identification. Each entity type has different options
 to be configured, here is an example for the "switch" entity:
 
 ![entity](https://github.com/rospogrigio/localtuya-homeassistant/blob/master/img/4-entity.png)
@@ -130,23 +132,23 @@ Energy monitoring (voltage, current...) values can be obtained in two different 
 1) creating individual sensors, each one with the desired name. Note: Voltage and Consumption usually include the first decimal, so 0.1 as "scaling" parameter shall be used in order to get the correct values.
 2) accessing the voltage/current/current_consumption attributes of a switch, and then defining template sensors like this (please note that in this case the values are already divided by 10 for Voltage and Consumption):
 
-```   
+```
        sensor:
          - platform: template
            sensors:
              tuya-sw01_voltage:
                value_template: >-
                  {{ states.switch.sw01.attributes.voltage }}
-               unit_of_measurement: 'V' 
+               unit_of_measurement: 'V'
              tuya-sw01_current:
-               value_template: >-     
+               value_template: >-
                  {{ states.switch.sw01.attributes.current }}
-               unit_of_measurement: 'mA'      
+               unit_of_measurement: 'mA'
              tuya-sw01_current_consumption:
                value_template: >-
                  {{ states.switch.sw01.attributes.current_consumption }}
-               unit_of_measurement: 'W' 
-```   
+               unit_of_measurement: 'W'
+```
 
 # Debugging
 
@@ -165,9 +167,9 @@ logger:
 
 # To-do list:
 
-* Create a (good and precise) sensor (counter) for Energy (kWh) -not just Power, but based on it-. 
+* Create a (good and precise) sensor (counter) for Energy (kWh) -not just Power, but based on it-.
       Ideas: Use: https://www.home-assistant.io/components/integration/ and https://www.home-assistant.io/components/utility_meter/
-   
+
 * Everything listed in https://github.com/rospogrigio/localtuya-homeassistant/issues/15
 
 # Thanks to:

--- a/custom_components/localtuya/const.py
+++ b/custom_components/localtuya/const.py
@@ -15,6 +15,9 @@ CONF_COLOR = "color"
 CONF_COLOR_MODE = "color_mode"
 CONF_COLOR_TEMP_MIN_KELVIN = "color_temp_min_kelvin"
 CONF_COLOR_TEMP_MAX_KELVIN = "color_temp_max_kelvin"
+CONF_SCENES = "scenes"
+CONF_SCENE_DATA = "scene_data"
+CONF_MUSIC_MODE = "music_mode"
 
 # switch
 CONF_CURRENT = "current"

--- a/custom_components/localtuya/const.py
+++ b/custom_components/localtuya/const.py
@@ -15,8 +15,6 @@ CONF_COLOR = "color"
 CONF_COLOR_MODE = "color_mode"
 CONF_COLOR_TEMP_MIN_KELVIN = "color_temp_min_kelvin"
 CONF_COLOR_TEMP_MAX_KELVIN = "color_temp_max_kelvin"
-CONF_SCENES = "scenes"
-CONF_SCENE_DATA = "scene_data"
 CONF_MUSIC_MODE = "music_mode"
 
 # switch

--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -341,7 +341,7 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
         if supported & SUPPORT_BRIGHTNESS:
             self._brightness = self.dps_conf(CONF_BRIGHTNESS)
 
-        if self.__is_color_mode():
+        if supported & SUPPORT_COLOR:
             color = self.dps_conf(CONF_COLOR)
             if color is not None:
                 if self.__is_color_rgb_encoded():

--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -311,6 +311,7 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
                         round(self._hs[0]), round(self._hs[1] * 10.0), brightness
                     )
                 states[self._config.get(CONF_COLOR)] = color
+                states[self._config.get(CONF_COLOR_MODE)] = COLOR_MODE
 
         if ATTR_HS_COLOR in kwargs and (features & SUPPORT_COLOR):
             if brightness is None:
@@ -362,7 +363,7 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
 
         if supported & SUPPORT_COLOR:
             color = self.dps_conf(CONF_COLOR)
-            if color is not None:
+            if color is not None and not self.__is_white_mode():
                 if self.__is_color_rgb_encoded():
                     hue = int(color[6:10], 16)
                     sat = int(color[10:12], 16)

--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -47,7 +47,7 @@ CUSTOM_SCENE = "Custom"
 
 MUSIC_SCENE = "Music"
 
-SCENE_LIST_1 = {
+SCENE_LIST_RGBW_1000 = {
     "Night": "000e0d0000000000000000c80000",
     "Read": "010e0d0000000000000003e801f4",
     "Meeting": "020e0d0000000000000003e803e8",
@@ -62,7 +62,7 @@ SCENE_LIST_1 = {
     + "3e800000000",
 }
 
-SCENE_LIST_2 = {
+SCENE_LIST_RGBW_255 = {
     "Night": "bd76000168ffff",
     "Read": "fffcf70168ffff",
     "Meeting": "cf38000168ffff",
@@ -71,6 +71,22 @@ SCENE_LIST_2 = {
     "Scenario 2": "scene_2",
     "Scenario 3": "scene_3",
     "Scenario 4": "scene_4",
+}
+
+SCENE_LIST_RGB_1000 = {
+    "Night": "000e0d00002e03e802cc00000000",
+    "Read": "010e0d000084000003e800000000",
+    "Working": "020e0d00001403e803e800000000",
+    "Leisure": "030e0d0000e80383031c00000000",
+    "Soft": "04464602007803e803e800000000464602007803e8000a00000000",
+    "Colorful": "05464601000003e803e800000000464601007803e803e80000000046460100f003e80"
+    + "3e800000000464601003d03e803e80000000046460100ae03e803e800000000464601011303e803"
+    + "e800000000",
+    "Dazzling": "06464601000003e803e800000000464601007803e803e80000000046460100f003e80"
+    + "3e800000000",
+    "Music": "07464602000003e803e800000000464602007803e803e80000000046460200f003e803e8"
+    + "00000000464602003d03e803e80000000046460200ae03e803e800000000464602011303e803e80"
+    + "0000000",
 }
 
 
@@ -143,9 +159,12 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
         self._effect_list = []
         self._scenes = None
         if self._config.get(CONF_SCENE) is not None:
-            self._scenes = (
-                SCENE_LIST_1 if self._config.get(CONF_SCENE) > 20 else SCENE_LIST_2
-            )
+            if self._config.get(CONF_SCENE) < 20:
+                self._scenes = SCENE_LIST_RGBW_255
+            elif self._config.get(CONF_BRIGHTNESS) is None:
+                self._scenes = SCENE_LIST_RGB_1000
+            else:
+                self._scenes = SCENE_LIST_RGBW_1000
             for scene in self._scenes:
                 self._effect_list.append(scene)
         if self._config.get(CONF_MUSIC_MODE):

--- a/custom_components/localtuya/translations/en.json
+++ b/custom_components/localtuya/translations/en.json
@@ -63,7 +63,9 @@
                     "color": "Color",
                     "color_mode": "Color Mode",
                     "color_temp_min_kelvin": "Minimum Color Temperature in K",
-                    "color_temp_max_kelvin": "Maximum Color Temperature in K"
+                    "color_temp_max_kelvin": "Maximum Color Temperature in K",
+                    "music_mode": "Music mode available",
+                    "scene": "Scene"
                 }
             }
         }
@@ -107,7 +109,9 @@
                     "color": "Color",
                     "color_mode": "Color Mode",
                     "color_temp_min_kelvin": "Minimum Color Temperature in K",
-                    "color_temp_max_kelvin": "Maximum Color Temperature in K"
+                    "color_temp_max_kelvin": "Maximum Color Temperature in K",
+                    "music_mode": "Music mode available",
+                    "scene": "Scene"
                 }
             },
             "yaml_import": {


### PR DESCRIPTION
This PR is adding basic supports of scenes for tuya lights.

```yaml
     - platform: light
        friendly_name: Device Light
        id: 4 # Usually 1 or 20
...
        scene: 25 # Optional, usually 6 (RGB_HSV) or 25 (HSV), default: "none"
        music_mode: False # Optional, some use internal mic, others, phone mic. Only internal mic is supported, default: "False"
```
We cannot get the scenes from the lights.
So this PR uses default scenes stored in the app for both RGB and HSV light bulbs.
If a scene is modified in the app, it appears as custom and but could not be use in a home assistant scene.

The music mode is also added but should only works with specific hardware that have a mic.
