### PR TITLE
Fan controller updates

### DIFF
--- a/custom_components/localtuya/const.py
+++ b/custom_components/localtuya/const.py
@@ -29,6 +29,13 @@ CONF_SET_POSITION_DP = "set_position_dp"
 CONF_POSITION_INVERTED = "position_inverted"
 CONF_SPAN_TIME = "span_time"
 
+# fan
+CONF_FAN_SPEED_CONTROL = "fan_speed_control"
+CONF_FAN_OSCILLATING_CONTROL = "fan_oscillating_control"
+CONF_FAN_SPEED_LOW = "fan_speed_low"
+CONF_FAN_SPEED_MEDIUM = "fan_speed_medium"
+CONF_FAN_SPEED_HIGH = "fan_speed_high"
+
 # sensor
 CONF_SCALING = "scaling"
 

--- a/custom_components/localtuya/fan.py
+++ b/custom_components/localtuya/fan.py
@@ -84,7 +84,7 @@ class LocaltuyaFan(LocalTuyaEntity, FanEntity):
 
     async def async_turn_on(self, speed: str = None, **kwargs) -> None:
         """Turn on the entity."""
-        await self._device.set_dp(True, "1")
+        await self._device.set_dp(True, self._dp_id)
         if speed is not None:
             await self.async_set_speed(speed)
         else:
@@ -92,7 +92,7 @@ class LocaltuyaFan(LocalTuyaEntity, FanEntity):
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn off the entity."""
-        await self._device.set_dp(False, "1")
+        await self._device.set_dp(False, self._dp_id)
         self.schedule_update_ha_state()
 
     async def async_set_speed(self, speed: str) -> None:
@@ -104,7 +104,7 @@ class LocaltuyaFan(LocalTuyaEntity, FanEntity):
         }
 
         if speed == SPEED_OFF:
-            await self._device.set_dp(False, "1")
+            await self._device.set_dp(False, self._dp_id)
         else:
             await self._device.set_dp(
                 mapping.get(speed), self._config.get(CONF_FAN_SPEED_CONTROL)

--- a/custom_components/localtuya/fan.py
+++ b/custom_components/localtuya/fan.py
@@ -84,7 +84,7 @@ class LocaltuyaFan(LocalTuyaEntity, FanEntity):
 
     async def async_turn_on(self, speed: str = None, **kwargs) -> None:
         """Turn on the entity."""
-        await self._device.set_dps(True, "1")
+        await self._device.set_dp(True, "1")
         if speed is not None:
             await self.async_set_speed(speed)
         else:
@@ -92,7 +92,7 @@ class LocaltuyaFan(LocalTuyaEntity, FanEntity):
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn off the entity."""
-        await self._device.set_dps(False, "1")
+        await self._device.set_dp(False, "1")
         self.schedule_update_ha_state()
 
     async def async_set_speed(self, speed: str) -> None:
@@ -104,9 +104,9 @@ class LocaltuyaFan(LocalTuyaEntity, FanEntity):
         }
 
         if speed == SPEED_OFF:
-            await self._device.set_dps(False, "1")
+            await self._device.set_dp(False, "1")
         else:
-            await self._device.set_dps(
+            await self._device.set_dp(
                 mapping.get(speed), self._config.get(CONF_FAN_SPEED_CONTROL)
             )
 
@@ -114,7 +114,7 @@ class LocaltuyaFan(LocalTuyaEntity, FanEntity):
 
     async def async_oscillate(self, oscillating: bool) -> None:
         """Set oscillation."""
-        await self._device.set_dps(
+        await self._device.set_dp(
             oscillating, self._config.get(CONF_FAN_OSCILLATING_CONTROL)
         )
         self.schedule_update_ha_state()

--- a/custom_components/localtuya/fan.py
+++ b/custom_components/localtuya/fan.py
@@ -2,16 +2,27 @@
 import logging
 from functools import partial
 
+import voluptuous as vol
+
 from homeassistant.components.fan import (
+    FanEntity,
     DOMAIN,
-    SPEED_HIGH,
+    SPEED_OFF,
     SPEED_LOW,
     SPEED_MEDIUM,
-    SPEED_OFF,
-    SUPPORT_OSCILLATE,
+    SPEED_HIGH,
     SUPPORT_SET_SPEED,
-    FanEntity,
+    SUPPORT_OSCILLATE,
 )
+
+from .const import (
+    CONF_FAN_SPEED_CONTROL,
+    CONF_FAN_OSCILLATING_CONTROL,
+    CONF_FAN_SPEED_LOW,
+    CONF_FAN_SPEED_MEDIUM,
+    CONF_FAN_SPEED_HIGH,
+)
+
 
 from .common import LocalTuyaEntity, async_setup_entry
 
@@ -20,7 +31,19 @@ _LOGGER = logging.getLogger(__name__)
 
 def flow_schema(dps):
     """Return schema used in config flow."""
-    return {}
+    return {
+        vol.Optional(CONF_FAN_SPEED_CONTROL): vol.In(dps),
+        vol.Optional(CONF_FAN_OSCILLATING_CONTROL): vol.In(dps),
+        vol.Optional(CONF_FAN_SPEED_LOW, default=SPEED_LOW): vol.In(
+            [SPEED_LOW, "1", "2"]
+        ),
+        vol.Optional(CONF_FAN_SPEED_MEDIUM, default=SPEED_MEDIUM): vol.In(
+            [SPEED_MEDIUM, "mid", "2", "3"]
+        ),
+        vol.Optional(CONF_FAN_SPEED_HIGH, default=SPEED_HIGH): vol.In(
+            [SPEED_HIGH, "auto", "3", "4"]
+        ),
+    }
 
 
 class LocaltuyaFan(LocalTuyaEntity, FanEntity):
@@ -61,7 +84,7 @@ class LocaltuyaFan(LocalTuyaEntity, FanEntity):
 
     async def async_turn_on(self, speed: str = None, **kwargs) -> None:
         """Turn on the entity."""
-        await self._device.set_dp(True, "1")
+        await self._device.set_dps(True, "1")
         if speed is not None:
             await self.async_set_speed(speed)
         else:
@@ -69,43 +92,68 @@ class LocaltuyaFan(LocalTuyaEntity, FanEntity):
 
     async def async_turn_off(self, **kwargs) -> None:
         """Turn off the entity."""
-        await self._device.set_dp(False, "1")
+        await self._device.set_dps(False, "1")
         self.schedule_update_ha_state()
 
     async def async_set_speed(self, speed: str) -> None:
         """Set the speed of the fan."""
+        mapping = {
+            SPEED_LOW: self._config.get(CONF_FAN_SPEED_LOW),
+            SPEED_MEDIUM: self._config.get(CONF_FAN_SPEED_MEDIUM),
+            SPEED_HIGH: self._config.get(CONF_FAN_SPEED_HIGH),
+        }
+
         if speed == SPEED_OFF:
-            await self._device.set_dp(False, "1")
-        elif speed == SPEED_LOW:
-            await self._device.set_dp("1", "2")
-        elif speed == SPEED_MEDIUM:
-            await self._device.set_dp("2", "2")
-        elif speed == SPEED_HIGH:
-            await self._device.set_dp("3", "2")
+            await self._device.set_dps(False, "1")
+        else:
+            await self._device.set_dps(
+                mapping.get(speed), self._config.get(CONF_FAN_SPEED_CONTROL)
+            )
+
         self.schedule_update_ha_state()
 
     async def async_oscillate(self, oscillating: bool) -> None:
         """Set oscillation."""
-        await self._device.set_dp(oscillating, "8")
+        await self._device.set_dps(
+            oscillating, self._config.get(CONF_FAN_OSCILLATING_CONTROL)
+        )
         self.schedule_update_ha_state()
 
     @property
     def supported_features(self) -> int:
         """Flag supported features."""
-        return SUPPORT_SET_SPEED | SUPPORT_OSCILLATE
+        supports = 0
+
+        if self.has_config(CONF_FAN_OSCILLATING_CONTROL):
+            supports |= SUPPORT_OSCILLATE
+        if self.has_config(CONF_FAN_SPEED_CONTROL):
+            supports |= SUPPORT_SET_SPEED
+
+        return supports
 
     def status_updated(self):
         """Get state of Tuya fan."""
-        self._is_on = self._status["dps"]["1"]
-        if not self._status["dps"]["1"]:
-            self._speed = SPEED_OFF
-        elif self._status["dps"]["2"] == "1":
-            self._speed = SPEED_LOW
-        elif self._status["dps"]["2"] == "2":
-            self._speed = SPEED_MEDIUM
-        elif self._status["dps"]["2"] == "3":
-            self._speed = SPEED_HIGH
-        self._oscillating = self._status["dps"]["8"]
+        mappings = {
+            self._config.get(CONF_FAN_SPEED_LOW): SPEED_LOW,
+            self._config.get(CONF_FAN_SPEED_MEDIUM): SPEED_MEDIUM,
+            self._config.get(CONF_FAN_SPEED_HIGH): SPEED_HIGH,
+        }
+
+        self._is_on = self.dps(self._dps_id)
+
+        if self.has_config(CONF_FAN_SPEED_CONTROL):
+            self._speed = mappings.get(self.dps_conf(CONF_FAN_SPEED_CONTROL))
+            if self.speed is None:
+                _LOGGER.warning(
+                    "%s/%s: Ignoring unknown fan controller state: %s",
+                    self.name,
+                    self.entity_id,
+                    self.dps_conf(CONF_FAN_SPEED_CONTROL),
+                )
+                self._speed = None
+
+        if self.has_config(CONF_FAN_OSCILLATING_CONTROL):
+            self._oscillating = self.dps_conf(CONF_FAN_OSCILLATING_CONTROL)
 
 
 async_setup_entry = partial(async_setup_entry, DOMAIN, LocaltuyaFan, flow_schema)

--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -115,12 +115,14 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
     @property
     def hs_color(self):
         """Return the hs color value."""
+        if self._is_white_mode:
+            return None
         return self._hs
 
     @property
     def color_temp(self):
         """Return the color_temp of the light."""
-        if self.has_config(CONF_COLOR_TEMP):
+        if self.has_config(CONF_COLOR_TEMP) and self._is_white_mode:
             return int(
                 self._max_mired
                 - (
@@ -239,7 +241,7 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
         if supported & SUPPORT_COLOR:
             self._is_white_mode = self.dps_conf(CONF_COLOR_MODE) == "white"
             if self._is_white_mode:
-                self._hs = [0, 0]
+                self._hs = None
 
         if self._is_white_mode:
             if supported & SUPPORT_BRIGHTNESS:

--- a/custom_components/localtuya/translations/en.json
+++ b/custom_components/localtuya/translations/en.json
@@ -63,7 +63,12 @@
                     "color": "Color",
                     "color_mode": "Color Mode",
                     "color_temp_min_kelvin": "Minimum Color Temperature in K",
-                    "color_temp_max_kelvin": "Maximum Color Temperature in K"
+                    "color_temp_max_kelvin": "Maximum Color Temperature in K",
+                    "fan_speed_control": "Fan Speed Control",
+                    "fan_oscillating_control": "Fan Oscillating Control",
+                    "fan_speed_low": "Fan Low Speed Setting",
+                    "fan_speed_medium": "Fan Medium Speed Setting",
+                    "fan_speed_high": "Fan High Speed Setting"
                 }
             }
         }
@@ -107,7 +112,12 @@
                     "color": "Color",
                     "color_mode": "Color Mode",
                     "color_temp_min_kelvin": "Minimum Color Temperature in K",
-                    "color_temp_max_kelvin": "Maximum Color Temperature in K"
+                    "color_temp_max_kelvin": "Maximum Color Temperature in K",
+                    "fan_speed_control": "Fan Speed Control",
+                    "fan_oscillating_control": "Fan Oscillating Control",
+                    "fan_speed_low": "Fan Low Speed Setting",
+                    "fan_speed_medium": "Fan Medium Speed Setting",
+                    "fan_speed_high": "Fan High Speed Setting"
                 }
             },
             "yaml_import": {


### PR DESCRIPTION
   
This updates the fan controller to be more dynamic on which dp's it uses.
    
Fan speeds can 1,2,3,4 or low,medium,mid,high,auto.  Fans with more
than 3 speeds is not supported by Home Assistant.
    
Variable speed fans are not supported at this time.

