### PR TITLE
Store product key in config entry

### DIFF
--- a/custom_components/localtuya/common.py
+++ b/custom_components/localtuya/common.py
@@ -19,7 +19,13 @@ from homeassistant.helpers.dispatcher import (
 from homeassistant.helpers.entity import Entity
 
 from . import pytuya
-from .const import CONF_LOCAL_KEY, CONF_PROTOCOL_VERSION, DOMAIN, TUYA_DEVICE
+from .const import (
+    CONF_LOCAL_KEY,
+    CONF_PRODUCT_KEY,
+    CONF_PROTOCOL_VERSION,
+    DOMAIN,
+    TUYA_DEVICE,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -257,7 +263,7 @@ class LocalTuyaEntity(Entity, pytuya.ContextualLogger):
             },
             "name": self._config_entry.data[CONF_FRIENDLY_NAME],
             "manufacturer": "Unknown",
-            "model": "Tuya generic",
+            "model": self._config_entry.data.get(CONF_PRODUCT_KEY, "Tuya generic"),
             "sw_version": self._config_entry.data[CONF_PROTOCOL_VERSION],
         }
 

--- a/custom_components/localtuya/const.py
+++ b/custom_components/localtuya/const.py
@@ -7,6 +7,7 @@ ATTR_VOLTAGE = "voltage"
 CONF_LOCAL_KEY = "local_key"
 CONF_PROTOCOL_VERSION = "protocol_version"
 CONF_DPS_STRINGS = "dps_strings"
+CONF_PRODUCT_KEY = "product_key"
 
 # light
 CONF_BRIGHTNESS_LOWER = "brightness_lower"

--- a/custom_components/localtuya/cover.py
+++ b/custom_components/localtuya/cover.py
@@ -1,7 +1,7 @@
 """Platform to locally control Tuya-based cover devices."""
 import asyncio
-import time
 import logging
+import time
 from functools import partial
 
 import voluptuous as vol


### PR DESCRIPTION
Store the device product key when creating a config entry. It will be automatically updated by the discovery in case it's missing in an existing config entry (e.g. prior to this PR or for YAML config). When available, it  be presented as the device model in the device registry.

I'm preparing a bit for the future "device database"-thing I've been talking about. It's a bit in the future, but I might as well do small tidbits when I get a feeling.