### PR TITLE
Fix broken exception logging

### DIFF
--- a/custom_components/localtuya/pytuya/__init__.py
+++ b/custom_components/localtuya/pytuya/__init__.py
@@ -137,7 +137,7 @@ class ContextualLogger:
 
     def exception(self, msg, *args):
         """Exception level log."""
-        return self._logger.log(logging.EXCEPTION, msg, *args)
+        return self._logger.exception(msg, *args)
 
 
 def pack_message(msg):


### PR DESCRIPTION
Seen as:

    AttributeError: module 'logging' has no attribute 'EXCEPTION'