### PR TITLE
Make re-connect logic more robust

### DIFF
--- a/custom_components/localtuya/__init__.py
+++ b/custom_components/localtuya/__init__.py
@@ -230,7 +230,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     )
 
     hass.data[DOMAIN][entry.entry_id][UNSUB_LISTENER]()
-    hass.data[DOMAIN][entry.entry_id][TUYA_DEVICE].close()
+    await hass.data[DOMAIN][entry.entry_id][TUYA_DEVICE].close()
     if unload_ok:
         hass.data[DOMAIN].pop(entry.entry_id)
 


### PR DESCRIPTION
This change fixes a few problems with the current re-connect loop, where no re-connect attempts would be made. This usually happens if a device is already in use by someone else (e.g. app). It also fixes a problem where the heartbeater task would not quit (yielding those pesky `AttributeError: 'NoneType' object has no attribute 'write'` errors). I have only tested it myself, but I would like to get feedback from at least someone else. Gonna ask for help in #160.