### PR TITLE
Includes switch functionality in lights

### DIFF
--- a/custom_components/localtuya/const.py
+++ b/custom_components/localtuya/const.py
@@ -10,6 +10,7 @@ CONF_DPS_STRINGS = "dps_strings"
 CONF_PRODUCT_KEY = "product_key"
 
 # light
+CONF_SWITCH_DP = "switch_dp"
 CONF_BRIGHTNESS_LOWER = "brightness_lower"
 CONF_BRIGHTNESS_UPPER = "brightness_upper"
 CONF_COLOR = "color"

--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -21,6 +21,7 @@ from homeassistant.const import CONF_BRIGHTNESS, CONF_COLOR_TEMP, CONF_SCENE
 
 from .common import LocalTuyaEntity, async_setup_entry
 from .const import (
+    CONF_SWITCH_DP,
     CONF_BRIGHTNESS_LOWER,
     CONF_BRIGHTNESS_UPPER,
     CONF_COLOR,

--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -370,7 +370,7 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
     async def async_turn_off(self, **kwargs):
         """Turn Tuya light off."""
         await self._device.set_dp(False, self._dp_id)
-        
+
         if self._switch_dp:
             await self._device.set_dp(False, self._switch_dp)
 

--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -377,7 +377,7 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
     def status_updated(self):
         """Device status was updated."""
         if self._switch_dp:
-            self._state = self.dps(self._switch_id)
+            self._state = self.dps(self._switch_dp)
         else:
             self._state = self.dps(self._dp_id)
 


### PR DESCRIPTION
I ran in to an issue where I had to add my Tuya bulbs as a separate `light` and a `switch` entity. I could adjust the brightness on the light entity, but in order to turn it on/off I had to use the switch entity. In Home Assistant, usually you can control a light's state and brightness as part of the same entity.

I really didn't spent a ton of time understanding your library, but I did manage to get this to work. Essentially, I had to include a `switch_dp` setting on the configuration for a light, so that if it's set, it will use this when turning on or off the light.

I'm not even sure what `dp` stands for and am unsure if this was the correct approach, happy to make adjustments.