### PR TITLE
Update cover fake set position

### DIFF
--- a/custom_components/localtuya/cover.py
+++ b/custom_components/localtuya/cover.py
@@ -155,10 +155,16 @@ class LocaltuyaCover(LocalTuyaEntity, CoverEntity):
                 self.debug("No moviment")
                 return
             elif distance > 0:
-                self.debug("Opening to %f - distance %f - delay %f", newpos, distance, mydelay)
+                self.debug(
+                    "Opening to %f - distance %f - delay %f",
+                    newpos, distance, mydelay
+                )
                 await self.async_open_cover()
             elif distance < 0:
-                self.debug("Closing to %f - distance %f - delay %f", newpos, distance, mydelay)
+                self.debug(
+                    "Closing to %f - distance %f - delay %f", 
+                    newpos, distance, mydelay
+                )
                 await self.async_close_cover()
             await asyncio.sleep(mydelay)
             await self.async_stop_cover()

--- a/custom_components/localtuya/cover.py
+++ b/custom_components/localtuya/cover.py
@@ -65,16 +65,18 @@ class LocaltuyaCover(LocalTuyaEntity, CoverEntity):
         """Initialize a new LocaltuyaCover."""
         super().__init__(device, config_entry, switchid, _LOGGER, **kwargs)
         self._state = None
-        self._current_cover_position = 50
+        self._current_cover_position = None
         commands_set = DEFAULT_COMMANDS_SET
         if self.has_config(CONF_COMMANDS_SET):
             commands_set = self._config[CONF_COMMANDS_SET]
         self._open_cmd = commands_set.split("_")[0]
         self._close_cmd = commands_set.split("_")[1]
         self._stop_cmd = commands_set.split("_")[2]
-        self._timer_start = time.time()
-        self._previous_state = self._stop_cmd
+        self._timer_start = None
+        self._previous_state = None
+        self._state = self._stop_cmd
         print("Initialized cover [{}]".format(self.name))
+        self.debug("initializing: %s", self._current_cover_position, self._state)
 
     @property
     def supported_features(self):
@@ -104,15 +106,21 @@ class LocaltuyaCover(LocalTuyaEntity, CoverEntity):
     @property
     def is_open(self):
         """Return if the cover is open or not."""
-        if self._config[CONF_POSITIONING_MODE] != COVER_MODE_POSITION:
+        if self._config[CONF_POSITIONING_MODE] == COVER_MODE_NONE:
             return None
 
-        return self._current_cover_position == 100
+        elif self._current_cover_position is None:
+            return None
+
+        return self._current_cover_position > 0
 
     @property
     def is_closed(self):
         """Return if the cover is closed or not."""
-        if self._config[CONF_POSITIONING_MODE] != COVER_MODE_POSITION:
+        if self._config[CONF_POSITIONING_MODE] == COVER_MODE_NONE:
+            return None
+
+        elif self._current_cover_position is None:
             return None
 
         return self._current_cover_position == 0
@@ -122,15 +130,35 @@ class LocaltuyaCover(LocalTuyaEntity, CoverEntity):
         self.debug("Setting cover position: %r", kwargs[ATTR_POSITION])
         if self._config[CONF_POSITIONING_MODE] == COVER_MODE_FAKE:
             newpos = float(kwargs[ATTR_POSITION])
+            spantime = self._config[CONF_SPAN_TIME]
 
             currpos = self.current_cover_position
-            posdiff = abs(newpos - currpos)
-            mydelay = posdiff / 50.0 * self._config[CONF_SPAN_TIME]
-            if newpos > currpos:
-                self.debug("Opening to %f: delay %f", newpos, mydelay)
-                await self.async_open_cover()
+            if currpos is None:
+                self.debug("Fully close to ensure position. Delay: %f", spantime)
+                await self.async_close_cover()
+                await asyncio.sleep(spantime)
+                await self.async_stop_cover()
+                await asyncio.sleep(1)
+                currpos = self._current_cover_position = 0
+
+            distance = 0
+            mydelay = spantime
+            if newpos < 5:
+                distance = -100
+            elif newpos > 95:
+                distance = +100
             else:
-                self.debug("Closing to %f: delay %f", newpos, mydelay)
+                distance = newpos - currpos
+                mydelay = abs(distance * spantime / 100.0)
+
+            if distance == 0:
+                self.debug("No moviment")
+                return
+            elif distance > 0:
+                self.debug("Opening to %f - distance %f - delay %f", newpos, distance, mydelay)
+                await self.async_open_cover()
+            elif distance < 0:
+                self.debug("Closing to %f - distance %f - delay %f", newpos, distance, mydelay)
                 await self.async_close_cover()
             await asyncio.sleep(mydelay)
             await self.async_stop_cover()
@@ -183,12 +211,18 @@ class LocaltuyaCover(LocalTuyaEntity, CoverEntity):
             if self._previous_state != self._stop_cmd:
                 # the state has changed, and the cover was moving
                 time_diff = time.time() - self._timer_start
-                pos_diff = round(time_diff / self._config[CONF_SPAN_TIME] * 50.0)
+                pos_diff = round(time_diff / self._config[CONF_SPAN_TIME] * 100.0)
                 if self._previous_state == self._close_cmd:
                     pos_diff = -pos_diff
-                self._current_cover_position = min(
-                    100, max(0, self._current_cover_position + pos_diff)
-                )
+
+                if pos_diff >= 100:
+                    self._current_cover_position = 100
+                elif pos_diff <= -100:
+                    self._current_cover_position = 0
+                elif self._current_cover_position is not None:
+                    self._current_cover_position = min(
+                        100, max(0, self._current_cover_position + pos_diff)
+                    )
 
                 change = "stopped" if self._state == self._stop_cmd else "inverted"
                 self.debug(

--- a/custom_components/localtuya/cover.py
+++ b/custom_components/localtuya/cover.py
@@ -162,7 +162,7 @@ class LocaltuyaCover(LocalTuyaEntity, CoverEntity):
                 await self.async_open_cover()
             elif distance < 0:
                 self.debug(
-                    "Closing to %f - distance %f - delay %f", 
+                    "Closing to %f - distance %f - delay %f",
                     newpos, distance, mydelay
                 )
                 await self.async_close_cover()


### PR DESCRIPTION
Changed the behavior of the FakeMode:
1) it starts with Unknow current_position
2) if the user moves up/down its wont change the current_position (it remaing unknow)
3) to the current_position became valid, needs:
* close by SpanTime (when this happen we know for sure that the position is 0)
* open by SpanTime (when this happen we know for sure that the position is 100)
* setPosition, the first time the cover will be fully close and then move to the desired position