### PR TITLE
Fix improper closing in config flow

### DIFF
--- a/custom_components/localtuya/config_flow.py
+++ b/custom_components/localtuya/config_flow.py
@@ -177,7 +177,7 @@ async def validate_input(hass: core.HomeAssistant, data):
         raise InvalidAuth
     finally:
         if interface:
-            interface.close()
+            await interface.close()
 
     # Indicate an error if no datapoints found as the rest of the flow
     # won't work in this case


### PR DESCRIPTION
Forgot to add an await to the close method in pytuya when validating the
device. This results in the connection never being closed after adding a
device, giving "connection resets" until the connection fails, the
device or Home Assistant is restarted.