### PR TITLE
Fix light state change when already on

### DIFF
--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -284,8 +284,8 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
     async def async_turn_on(self, **kwargs):
         """Turn on or control the light."""
         states = {}
-		if not self.is_on:
-	        states[self._dp_id] = True
+        if not self.is_on:
+            states[self._dp_id] = True
         features = self.supported_features
         brightness = None
         if ATTR_EFFECT in kwargs and (features & SUPPORT_EFFECT):

--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -284,7 +284,8 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
     async def async_turn_on(self, **kwargs):
         """Turn on or control the light."""
         states = {}
-        states[self._dp_id] = True
+		if not self.is_on:
+	        states[self._dp_id] = True
         features = self.supported_features
         brightness = None
         if ATTR_EFFECT in kwargs and (features & SUPPORT_EFFECT):


### PR DESCRIPTION
I noticed that, when using localtuya, changing the light from one state to another wasn't quite smooth. The light seemed to "turn off" and then go to the new state. For example, changing a light from red to green would make the light flash to being off, which was very unpleasant to the eyes.

I had a look in the code for localtuya and I found out that adding a simple `if`-statement in the `async_turn_on` function fixed this behavior.