### PR TITLE
Use debug message for timeout.

### DIFF
--- a/custom_components/localtuya/pytuya/__init__.py
+++ b/custom_components/localtuya/pytuya/__init__.py
@@ -383,6 +383,9 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
                 except asyncio.CancelledError:
                     self.debug("Stopped heartbeat loop")
                     raise
+                except asyncio.TimeoutError:
+                    self.debug("Heartbeat failed due to timeout, disconnecting")
+                    break
                 except Exception as ex:  # pylint: disable=broad-except
                     self.exception("Heartbeat failed (%s), disconnecting", ex)
                     break


### PR DESCRIPTION
As we have devices that can be physically off and on like bulbs, this PR is changing the timeout log to a debug one. 
It keeps dumping the stack of any other exception.