### PR TITLE
Fixed close button disabled with 'none' positioning mode

### DIFF
--- a/custom_components/localtuya/cover.py
+++ b/custom_components/localtuya/cover.py
@@ -88,6 +88,8 @@ class LocaltuyaCover(LocalTuyaEntity, CoverEntity):
     @property
     def current_cover_position(self):
         """Return current cover position in percent."""
+        if self._config[CONF_POSITIONING_MODE] == COVER_MODE_NONE:
+            return None
         return self._current_cover_position
 
     @property


### PR DESCRIPTION
Fixed close button disabled with 'none' positioning mode: if positioning is not used, `current_cover_position` method shall return None.