### PR TITLE
Introducing support for Zigbee Wifi gateway

### DIFF
--- a/custom_components/localtuya/pytuya/__init__.py
+++ b/custom_components/localtuya/pytuya/__init__.py
@@ -87,7 +87,7 @@ HEARTBEAT_INTERVAL = 10
 # length, zero padding implies could be more than one byte)
 PAYLOAD_DICT = {
     "type_0a": {
-        STATUS: {"hexByte": 0x0A, "command": {"gwId": "", "devId": ""}},
+        STATUS: {"hexByte": 0x0A, "command": {"gwId": "", "devId": "", "cid": ""}},
         SET: {"hexByte": 0x07, "command": {"devId": "", "uid": "", "t": ""}},
         HEARTBEAT: {"hexByte": 0x09, "command": {}},
     },
@@ -578,6 +578,8 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
             json_data["devId"] = self.id
         if "uid" in json_data:
             json_data["uid"] = self.id  # still use id, no separate uid
+        if "cid" in json_data:
+            json_data["cid"] = self.id  # still use id, no separate uid
         if "t" in json_data:
             json_data["t"] = str(int(time.time()))
 


### PR DESCRIPTION
Introducing support for devices connected via a zigbee wifi gateway. 
PLEASE NOTE: In order to make them work, the user needs to obtain the device **cid** (which is DIFFERENT from its deviceId, or the gateway deviceId): the only way to find it is to sniff traffic to the device, and decrypt it.
