### PR TITLE
Include "big" high fan setting

### DIFF
--- a/custom_components/localtuya/fan.py
+++ b/custom_components/localtuya/fan.py
@@ -38,7 +38,7 @@ def flow_schema(dps):
             [SPEED_MEDIUM, "mid", "2", "3"]
         ),
         vol.Optional(CONF_FAN_SPEED_HIGH, default=SPEED_HIGH): vol.In(
-            [SPEED_HIGH, "auto", "3", "4", "large"]
+            [SPEED_HIGH, "auto", "3", "4", "large", "big"]
         ),
     }
 


### PR DESCRIPTION
The Asakuki diffuser has its speed setting under the 103 DPS and uses "big" for its high setting.