### PR TITLE
Add support for setting fan direction

### DIFF
--- a/custom_components/localtuya/const.py
+++ b/custom_components/localtuya/const.py
@@ -34,6 +34,7 @@ CONF_SPAN_TIME = "span_time"
 # fan
 CONF_FAN_SPEED_CONTROL = "fan_speed_control"
 CONF_FAN_OSCILLATING_CONTROL = "fan_oscillating_control"
+CONF_FAN_DIRECTION = "fan_direction"
 CONF_FAN_SPEED_LOW = "fan_speed_low"
 CONF_FAN_SPEED_MEDIUM = "fan_speed_medium"
 CONF_FAN_SPEED_HIGH = "fan_speed_high"

--- a/custom_components/localtuya/fan.py
+++ b/custom_components/localtuya/fan.py
@@ -1,4 +1,5 @@
 """Platform to locally control Tuya-based fan devices."""
+from __future__ import annotations
 import logging
 from functools import partial
 
@@ -69,7 +70,7 @@ class LocaltuyaFan(LocalTuyaEntity, FanEntity):
         return self._oscillating
 
     @property
-    def current_direction(self) -> str:
+    def current_direction(self) -> str | None:
         """Return current direction of the fan."""
         return self._direction
 

--- a/custom_components/localtuya/fan.py
+++ b/custom_components/localtuya/fan.py
@@ -127,9 +127,7 @@ class LocaltuyaFan(LocalTuyaEntity, FanEntity):
 
     async def async_set_direction(self, direction: str) -> None:
         """Set direction."""
-        await self._device.set_dp(
-            direction, self._config.get(CONF_FAN_DIRECTION)
-        )
+        await self._device.set_dp(direction, self._config.get(CONF_FAN_DIRECTION))
         self.schedule_update_ha_state()
 
     @property

--- a/custom_components/localtuya/translations/en.json
+++ b/custom_components/localtuya/translations/en.json
@@ -72,6 +72,7 @@
                     "scene": "Scene",
                     "fan_speed_control": "Fan Speed Control",
                     "fan_oscillating_control": "Fan Oscillating Control",
+                    "fan_direction": "Fan Direction",
                     "fan_speed_low": "Fan Low Speed Setting",
                     "fan_speed_medium": "Fan Medium Speed Setting",
                     "fan_speed_high": "Fan High Speed Setting"
@@ -124,6 +125,7 @@
                     "scene": "Scene",
                     "fan_speed_control": "Fan Speed Control",
                     "fan_oscillating_control": "Fan Oscillating Control",
+                    "fan_direction": "Fan Direction",
                     "fan_speed_low": "Fan Low Speed Setting",
                     "fan_speed_medium": "Fan Medium Speed Setting",
                     "fan_speed_high": "Fan High Speed Setting"


### PR DESCRIPTION
My recently purchased [Arlec 130cm White 4 Blade Grid Connect Smart DC Ceiling Fan](https://www.bunnings.com.au/arlec-130cm-white-4-blade-grid-connect-smart-dc-ceiling-fan-with-remote_p0104210) runs great on LocalTuya. Both the fan and the HA fan component support changing the direction that the fan spins, and this simple change in LocalTuya has allowed me to control the fan direction in HA.