### PR TITLE
[covers] bug: state is not reported properly

### DIFF
--- a/custom_components/localtuya/cover.py
+++ b/custom_components/localtuya/cover.py
@@ -105,20 +105,15 @@ class LocaltuyaCover(LocalTuyaEntity, CoverEntity):
         return state == self._close_cmd
 
     @property
-    def is_open(self):
-        """Return if the cover is open or not."""
-        if self._config[CONF_POSITIONING_MODE] != COVER_MODE_POSITION:
-            return None
-
-        return self._current_cover_position == 100
-
-    @property
     def is_closed(self):
         """Return if the cover is closed or not."""
-        if self._config[CONF_POSITIONING_MODE] != COVER_MODE_POSITION:
+        if self._config[CONF_POSITIONING_MODE] == COVER_MODE_NONE:
             return None
-
-        return self._current_cover_position == 0
+        elif self._current_cover_position == 0:
+            return True
+        elif self._current_cover_position == 100:
+            return False
+        return None
 
     async def async_set_cover_position(self, **kwargs):
         """Move the cover to a specific position."""

--- a/custom_components/localtuya/cover.py
+++ b/custom_components/localtuya/cover.py
@@ -109,9 +109,10 @@ class LocaltuyaCover(LocalTuyaEntity, CoverEntity):
         """Return if the cover is closed or not."""
         if self._config[CONF_POSITIONING_MODE] == COVER_MODE_NONE:
             return None
-        elif self._current_cover_position == 0:
+
+        if self._current_cover_position == 0:
             return True
-        elif self._current_cover_position == 100:
+        if self._current_cover_position == 100:
             return False
         return None
 


### PR DESCRIPTION
This PR comes to fix 2 things in the cover integration:
- The timed mode should report the opened/closed state
- Fix the state inference

According to the [docs](https://developers.home-assistant.io/docs/core/entity/cover/) and the [code](https://github.com/home-assistant/core/blob/2e029458332c34b440a5c0118baa98f91f74f051/homeassistant/components/cover/__init__.py#L208-L220) the `is_open` attirube doesn't even exist. And the `is_closed` attribute should report `True` if the cover is fully closed, `False` if the cover is fully open and `None` otherwise (cover is somewhere in a middle position)