### PR TITLE
Fix color temperature to use correct conversion and clamp to allowed range

### DIFF
--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -33,7 +33,6 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-MIRED_TO_KELVIN_CONST = 1000000
 DEFAULT_MIN_KELVIN = 2700  # MIRED 370
 DEFAULT_MAX_KELVIN = 6500  # MIRED 153
 
@@ -154,13 +153,11 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
             CONF_BRIGHTNESS_UPPER, DEFAULT_UPPER_BRIGHTNESS
         )
         self._upper_color_temp = self._upper_brightness
-        self._max_mired = round(
-            MIRED_TO_KELVIN_CONST
-            / self._config.get(CONF_COLOR_TEMP_MIN_KELVIN, DEFAULT_MIN_KELVIN)
+        self._max_mired = color_util.color_temperature_kelvin_to_mired(
+            self._config.get(CONF_COLOR_TEMP_MIN_KELVIN, DEFAULT_MIN_KELVIN)
         )
-        self._min_mired = round(
-            MIRED_TO_KELVIN_CONST
-            / self._config.get(CONF_COLOR_TEMP_MAX_KELVIN, DEFAULT_MAX_KELVIN)
+        self._min_mired = color_util.color_temperature_kelvin_to_mired(
+            self._config.get(CONF_COLOR_TEMP_MAX_KELVIN, DEFAULT_MAX_KELVIN)
         )
         self._color_temp_reverse = self._config.get(
             CONF_COLOR_TEMP_REVERSE, DEFAULT_COLOR_TEMP_REVERSE

--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -377,16 +377,17 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
         if ATTR_COLOR_TEMP in kwargs and (features & SUPPORT_COLOR_TEMP):
             if brightness is None:
                 brightness = self._brightness
-            color_temp_value = (
-                (self._max_mired - self._min_mired)
-                - (int(kwargs[ATTR_COLOR_TEMP]) - self._min_mired)
-                if self._color_temp_reverse
-                else (int(kwargs[ATTR_COLOR_TEMP]) - self._min_mired)
-            )
+            mired = int(kwargs[ATTR_COLOR_TEMP])
+            if self._color_temp_reverse:
+                mired = self._max_mired - (mired - self._min_mired)
+            if mired < self._min_mired:
+                mired = self._min_mired
+            elif mired > self._max_mired:
+                mired = self._max_mired
             color_temp = int(
                 self._upper_color_temp
                 - (self._upper_color_temp / (self._max_mired - self._min_mired))
-                * color_temp_value
+                * (mired - self._min_mired)
             )
             states[self._config.get(CONF_COLOR_MODE)] = MODE_WHITE
             states[self._config.get(CONF_BRIGHTNESS)] = brightness


### PR DESCRIPTION
If `light.turn_on` is invoked with `brightness: 128, color_temp: 500` for a bulb that supports mired range 154..370 in value range 1..255 the calculated color temperature will be negative.  When the bulb receives the command it will turn on, but will fail processing the `4: -153` command to set color_temp and will not send a response packet.
    
At this point `light.toggle` will have no effect because Home Assistant was never told the bulb was turned on, so the same erroneous turn-on command will be re-sent.
    
Fix this by clamping the sent color temperature to the allowed range.

This PR also includes a patch that solves the same problem as #577 but does so by using the core function rather than fixing the local reimplementation.