### PR TITLE
Show warning instead of Error exception trace in log when failing to connect to a device

### DIFF
--- a/custom_components/localtuya/common.py
+++ b/custom_components/localtuya/common.py
@@ -166,6 +166,11 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
             self._disconnect_task = async_dispatcher_connect(
                 self._hass, signal, _new_entity_handler
             )
+        except OSError:
+            _LOGGER.warning(f"Could not reach {self._config_entry[CONF_HOST]}, device might be offline.")
+            if self._interface is not None:
+                await self._interface.close()
+                self._interface = None
         except Exception:  # pylint: disable=broad-except
             self.exception(f"Connect to {self._config_entry[CONF_HOST]} failed")
             if self._interface is not None:


### PR DESCRIPTION
Shows only a warning in the log files if a device is offline.

This is a fairly common situation for light switches, and it
previously showed an "unreadable" exception as an Error.
Now it will just show a simple warning in the logs when
localtuya failed to reach the device.

Fixes #650