### PR TITLE
Fix broken state

### DIFF
--- a/custom_components/localtuya/cover.py
+++ b/custom_components/localtuya/cover.py
@@ -203,6 +203,8 @@ class LocaltuyaCover(LocalTuyaEntity, CoverEntity):
                 self._current_cover_position = 100 - curr_pos
             else:
                 self._current_cover_position = curr_pos
+            if self._state == "closing":
+                self._state = "stopped" 
         if (
             self._config[CONF_POSITIONING_MODE] == COVER_MODE_TIMED
             and self._state != self._previous_state


### PR DESCRIPTION
My covers get permanently stuck in 'closing'. Manually forcing the state to 'stopped' allows all the other is_closed / is_open etc to trigger correctly and the buttons start working form the UI again