### PR TITLE
fan: send integers when not using ordered list

### DIFF
--- a/custom_components/localtuya/fan.py
+++ b/custom_components/localtuya/fan.py
@@ -151,10 +151,8 @@ class LocaltuyaFan(LocalTuyaEntity, FanEntity):
 
             else:
                 await self._device.set_dp(
-                    str(
-                        math.ceil(
-                            percentage_to_ranged_value(self._speed_range, percentage)
-                        )
+                    math.ceil(
+                        percentage_to_ranged_value(self._speed_range, percentage)
                     ),
                     self._config.get(CONF_FAN_SPEED_CONTROL),
                 )


### PR DESCRIPTION
Without this change my fan was making weird (and probably dangerous) magnetic sounds and not changing the speed