### PR TITLE
Fixes type error when using an ordered list.

### DIFF
--- a/custom_components/localtuya/fan.py
+++ b/custom_components/localtuya/fan.py
@@ -221,7 +221,7 @@ class LocaltuyaFan(LocalTuyaEntity, FanEntity):
             )
             if current_speed is not None:
                 self._percentage = ordered_list_item_to_percentage(
-                    self._ordered_list, current_speed
+                    self._ordered_list, str(current_speed)
                 )
 
         else:


### PR DESCRIPTION
Fixes the error when using an ordered list.

2022-05-24 15:17:28 ERROR (SyncWorker_7) [homeassistant.util.logging] Exception in _update_handler when dispatching 'localtuya_xxxx': ({'20': False, '22': 1000, '23': 0, '60': True, '62': 3, '63': 'forward', '64': 0},)
Traceback (most recent call last):
  File "/config/custom_components/localtuya/common.py", line 281, in _update_handler
    self.status_updated()
  File "/config/custom_components/localtuya/fan.py", line 223, in status_updated
    self._percentage = ordered_list_item_to_percentage(:
  File "/usr/src/homeassistant/homeassistant/util/percentage.py", line 25, in ordered_list_item_to_percentage
    raise ValueError(f'The item "{item}"" is not in "{ordered_list}"')
ValueError: The item "3"" is not in "['1', '2', '3', '4', '5', '6']"