### PR TITLE
Fix #337 Add guard clauses

### DIFF
--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -94,7 +94,9 @@ SCENE_LIST_RGB_1000 = {
 
 def map_range(value, from_lower, from_upper, to_lower, to_upper):
     """Map a value in one range to another."""
-    mapped = (value - from_lower) * (to_upper - to_lower) / (
+    if value == None:
+        return 0
+    mapped = (int(value) - from_lower) * (to_upper - to_lower) / (
         from_upper - from_lower
     ) + to_lower
     return round(min(max(mapped, to_lower), to_upper))
@@ -185,6 +187,8 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
     @property
     def brightness(self):
         """Return the brightness of the light."""
+        if self._brightness == None:
+            return None
         if self.is_color_mode or self.is_white_mode:
             return map_range(
                 self._brightness, self._lower_brightness, self._upper_brightness, 0, 255


### PR DESCRIPTION
Still testing locally.

Avoids trying to do math if self._brightness is None, which is how it is instantiated.