### PR TITLE
Update climate.py for air conditioning

### DIFF
--- a/custom_components/localtuya/climate.py
+++ b/custom_components/localtuya/climate.py
@@ -12,9 +12,11 @@ from homeassistant.components.climate import (
 )
 from homeassistant.components.climate.const import (
     CURRENT_HVAC_HEAT,
+    CURRENT_HVAC_COOL,
     CURRENT_HVAC_IDLE,
     HVAC_MODE_AUTO,
     HVAC_MODE_HEAT,
+    HVAC_MODE_COOL,
     HVAC_MODE_OFF,
     PRESET_AWAY,
     PRESET_ECO,
@@ -59,18 +61,24 @@ _LOGGER = logging.getLogger(__name__)
 HVAC_MODE_SETS = {
     "manual/auto": {
         HVAC_MODE_HEAT: "manual",
+        HVAC_MODE_COOL: "manual",
         HVAC_MODE_AUTO: "auto",
     },
     "Manual/Auto": {
         HVAC_MODE_HEAT: "Manual",
+        HVAC_MODE_COOL: "Manual",
         HVAC_MODE_AUTO: "Auto",
     },
     "Manual/Program": {
         HVAC_MODE_HEAT: "Manual",
+        HVAC_MODE_COOL: "Manual",
         HVAC_MODE_AUTO: "Program",
     },
     "True/False": {
         HVAC_MODE_HEAT: True,
+    },
+    "True/False (Cool)": {
+        HVAC_MODE_COOL: True,
     },
     "1/0": {
         HVAC_MODE_HEAT: "1",
@@ -80,16 +88,22 @@ HVAC_MODE_SETS = {
 HVAC_ACTION_SETS = {
     "True/False": {
         CURRENT_HVAC_HEAT: True,
+        CURRENT_HVAC_COOL: True,
         CURRENT_HVAC_IDLE: False,
     },
     "open/close": {
         CURRENT_HVAC_HEAT: "open",
+        CURRENT_HVAC_COOL: "open",
         CURRENT_HVAC_IDLE: "close",
     },
     "heating/no_heating": {
         CURRENT_HVAC_HEAT: "heating",
         CURRENT_HVAC_IDLE: "no_heating",
     },
+    "cooling/no_cooling": {
+        CURRENT_HVAC_COOL: "cooling",
+        CURRENT_HVAC_IDLE: "no_cooling",
+    },    
     "Heat/Warming": {
         CURRENT_HVAC_HEAT: "Heat",
         CURRENT_HVAC_IDLE: "Warming",
@@ -243,6 +257,23 @@ class LocaltuyaClimate(LocalTuyaEntity, ClimateEntity):
                 ):
                     if self._hvac_action == CURRENT_HVAC_HEAT:
                         self._hvac_action = CURRENT_HVAC_HEAT
+                    if self._hvac_action == CURRENT_HVAC_IDLE:
+                        self._hvac_action = CURRENT_HVAC_IDLE
+                if (
+                    self._current_temperature + self._precision
+                ) > self._target_temperature:
+                    self._hvac_action = CURRENT_HVAC_IDLE
+            return self._hvac_action
+            if self._hvac_mode == HVAC_MODE_COOL:
+                if self._current_temperature < (
+                    self._target_temperature - self._precision
+                ):
+                    self._hvac_action = CURRENT_HVAC_COOL
+                if self._current_temperature == (
+                    self._target_temperature - self._precision
+                ):
+                    if self._hvac_action == CURRENT_HVAC_COOL:
+                        self._hvac_action = CURRENT_HVAC_COOL
                     if self._hvac_action == CURRENT_HVAC_IDLE:
                         self._hvac_action = CURRENT_HVAC_IDLE
                 if (


### PR DESCRIPTION
Some quick and dirty changes to climate.py to support air conditioning, since the current version seems to only be heat-centric. 

Likely need to put in a more refined way to differentiate between heat and cool, but adding an additional True/False HVAC mode for Cool allows HA to recognize my Tuya TCL window air conditioner as "cooling", while also letting me turn on/off the air conditioner with the "Cool" and "Off" options.
![Screenshot_2022-06-16_20-52-45](https://user-images.githubusercontent.com/67639253/174202702-ab73ba2f-2be3-4431-b821-7efe5100fc28.png)
![Screenshot_2022-06-16_21-11-47](https://user-images.githubusercontent.com/67639253/174202725-33ca59aa-bb77-4725-bf2a-3c5f82849cd3.png)

While not included in this PR, I also needed to manually adjust the default min and max temps because this TCL air conditioner does not provide DP's for min and max temperature, and the default ones in HA are designed for Celsius and do not work properly in a Fahrenheit configuration. It might be worth adding the ability to enter custom min/max temps within the integration. 

```
homeassistant:
  customize:
    climate.bedroomac:
      max_temp: 90
      min_temp: 10 
```