### PR TITLE
Split on regex instead of hard comma limit

### DIFF
--- a/custom_components/localtuya/fan.py
+++ b/custom_components/localtuya/fan.py
@@ -71,7 +71,7 @@ class LocaltuyaFan(LocalTuyaEntity, FanEntity):
             self._config.get(CONF_FAN_SPEED_MIN),
             self._config.get(CONF_FAN_SPEED_MAX),
         )
-        self._ordered_list = self._config.get(CONF_FAN_ORDERED_LIST).split(",")
+        self._ordered_list = self._config.get(CONF_FAN_ORDERED_LIST).split("[ ,]+")
         self._ordered_list_mode = None
 
         if isinstance(self._ordered_list, list) and len(self._ordered_list) > 1:


### PR DESCRIPTION
Changes it so people can use `,` or `, ` instead of only `,` in their modes array for improved UX