### PR TITLE
Pre-sets missing for Arlec Panel Heater PEH225HA

### DIFF
--- a/custom_components/localtuya/climate.py
+++ b/custom_components/localtuya/climate.py
@@ -101,6 +101,11 @@ PRESET_SETS = {
         PRESET_HOME: "Program",
         PRESET_NONE: "Manual",
     },
+    "Low/High": {
+        PRESET_AWAY: "",
+        PRESET_HOME: "high",
+        PRESET_NONE: "",
+    },
 }
 
 TEMPERATURE_CELSIUS = "celsius"


### PR DESCRIPTION
Added PRESET_SETS to allow changing modes between Low (1100W) and High (2200W)