### PR TITLE
support subdevice behind gateway

### DIFF
--- a/custom_components/localtuya/pytuya/__init__.py
+++ b/custom_components/localtuya/pytuya/__init__.py
@@ -93,7 +93,7 @@ UPDATE_DPS_WHITELIST = [18, 19, 20]  # Socket (Wi-Fi)
 # length, zero padding implies could be more than one byte)
 PAYLOAD_DICT = {
     "type_0a": {
-        STATUS: {"hexByte": 0x0A, "command": {"gwId": "", "devId": ""}},
+        STATUS: {"hexByte": 0x0A, "command": {"gwId": "", "devId": "", "cid": ""}},
         SET: {"hexByte": 0x07, "command": {"devId": "", "uid": "", "t": ""}},
         HEARTBEAT: {"hexByte": 0x09, "command": {}},
         UPDATEDPS: {"hexByte": 0x12, "command": {"dpId": [18, 19, 20]}},
@@ -642,6 +642,8 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
             json_data["devId"] = self.id
         if "uid" in json_data:
             json_data["uid"] = self.id  # still use id, no separate uid
+        if "cid" in json_data:
+            json_data["cid"] = self.id  # still use id, no separate uid
         if "t" in json_data:
             json_data["t"] = str(int(time.time()))
 


### PR DESCRIPTION
Support sub-device behind gateway, which are identified by CID.

Tested with Holman Wi-Fi Tap Timer which each Tap Timer are connect to ta Wi-Fi hub with single IP only.