### PR TITLE
Update climate.py - Add '1/0' option to HVAC_ACTION_SETS

### DIFF
--- a/custom_components/localtuya/climate.py
+++ b/custom_components/localtuya/climate.py
@@ -94,6 +94,10 @@ HVAC_ACTION_SETS = {
         CURRENT_HVAC_HEAT: "Heat",
         CURRENT_HVAC_IDLE: "Warming",
     },
+    "1/0": {
+        HVAC_MODE_HEAT: "1",
+        HVAC_MODE_IDLE: "0",
+    },
 }
 PRESET_SETS = {
     "Manual/Holiday/Program": {

--- a/custom_components/localtuya/climate.py
+++ b/custom_components/localtuya/climate.py
@@ -95,8 +95,8 @@ HVAC_ACTION_SETS = {
         CURRENT_HVAC_IDLE: "Warming",
     },
     "1/0": {
-        HVAC_MODE_HEAT: "1",
-        HVAC_MODE_IDLE: "0",
+        CURRENT_HVAC_HEAT: "1",
+        CURRENT_HVAC_IDLE: "0",
     },
 }
 PRESET_SETS = {


### PR DESCRIPTION
Adding a '1/0' option to HVAC_ACTION_SETS to support MK60E