### PR TITLE
Change default to add more entities

### DIFF
--- a/custom_components/localtuya/config_flow.py
+++ b/custom_components/localtuya/config_flow.py
@@ -663,7 +663,7 @@ class LocalTuyaOptionsFlowHandler(config_entries.OptionsFlow):
         schema = PICK_ENTITY_SCHEMA
         if self.selected_platform is not None:
             schema = schema.extend(
-                {vol.Required(NO_ADDITIONAL_ENTITIES, default=True): bool}
+                {vol.Required(NO_ADDITIONAL_ENTITIES, default=False): bool}
             )
 
         return self.async_show_form(step_id="pick_entity_type", data_schema=schema)


### PR DESCRIPTION
Since one cannot add more entities after first adding the device, change the default to prompt for more entities on first set up