### PR TITLE
Fix loss of control of Feit (Tuya) RGBW Strip after power failure

### DIFF
--- a/custom_components/localtuya/common.py
+++ b/custom_components/localtuya/common.py
@@ -204,6 +204,18 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
                 if status is None:
                     raise Exception("Failed to retrieve status")
 
+                # When a Feit/Tuya RGBW light strip loses power, the initial state
+                # returned here is missing the color value. If HASS didn't also
+                # lose power, it's ok since it retains the last value. But if it
+                # does, later calls to __is_color_rgb_encoded() in light.py fail
+                # (e.g. when changing strip color in the UI) with "Failed to call
+                # service light/turn_on -> TypeError: object of type 'NoneType'
+                # has no len()". This can be fixed by supplying a synthetic value
+                # (although it won't match the real strip's value until HASS
+                # changes the color again).
+                if "24" not in status:
+                    status["24"] = "000003e80111"
+
                 self._interface.start_heartbeat()
                 self.status_updated(status)
 


### PR DESCRIPTION
- this applies to the Feit (Tuya) RGBW LED Strip Light sold by Costco circa 2022
- this happens either after power failure or after HASS is rebooted while RGBW strip light is unplugged
- When the light strip loses power, the initial state returned to common.py is missing the color value. If HASS didn't also lose power, it's ok since HASS retains the last color value used. But if it does, later calls to __is_color_rgb_encoded() in light.py fail (e.g. when changing strip color in the UI) with "Failed to call service light/turn_on -> TypeError: object of type 'NoneType' has no len()". This can be fixed by supplying a synthetic value (although it won't match the real strip's value until HASS changes the color again).

![IMG_5635](https://user-images.githubusercontent.com/5867795/206872606-47d1a592-386c-440c-b5e6-141b46a68a9c.jpg)
