### PR TITLE
Added Support for IR Controls and new Climate HVAC_MODE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__
 .tox
 tuyadebug/
 .pre-commit-config.yaml
+.DS_Store

--- a/custom_components/localtuya/button.py
+++ b/custom_components/localtuya/button.py
@@ -1,0 +1,143 @@
+"""Platform to present any Tuya DP as an enumeration."""
+import logging
+from functools import partial
+import base64
+import json
+import struct
+import voluptuous as vol
+from homeassistant.components.button import DOMAIN, ButtonEntity
+from homeassistant.const import (
+    CONF_DEVICE_CLASS    
+)
+
+from .common import LocalTuyaEntity, async_setup_entry
+
+from .const import (CONF_IR_BUTTON, CONF_IR_BUTTON_FRIENDLY, CONF_IR_DP_ID)
+
+
+def flow_schema(dps):
+    """Return schema used in config flow."""
+    return {
+        vol.Required(CONF_IR_BUTTON): str,
+        vol.Required(CONF_IR_BUTTON_FRIENDLY): str,
+        vol.Required(CONF_IR_DP_ID): str,
+    }
+
+
+_LOGGER = logging.getLogger(__name__)
+NSDP_CONTROL = "control"       # The control commands
+NSDP_TYPE = "type"             # The identifier of an IR library
+NSDP_HEAD = "head"             # Actually used but not documented
+NSDP_KEY1 = "key1"             # Actually used but not documented
+
+class LocaltuyaIRButton(LocalTuyaEntity, ButtonEntity):
+    """Representation of a Tuya Enumeration."""
+    
+    def __init__(
+        self,
+        device,
+        config_entry,
+        sensorid,
+        **kwargs,
+    ):
+        """Initialize the Tuya sensor."""
+        dp_list = device.dps_to_request
+        generic_list = {}
+        for dp in list(dp_list):
+            generic_list[str(dp)] = "generic"
+        
+        self._status = generic_list
+        self._default_status = generic_list
+        
+        device._bypass_status = True
+        device._default_status = generic_list
+
+        super().__init__(device, config_entry, sensorid, _LOGGER, **kwargs)
+                
+        self._state = None
+        self._button_pronto = self._config.get(CONF_IR_BUTTON)
+        self._default_dp = self._config.get(CONF_IR_DP_ID)
+
+        # Set Display options
+        self._display_options = []
+        display_options_str = ""
+        if CONF_IR_BUTTON_FRIENDLY in self._config:
+            display_options_str = self._config.get(CONF_IR_BUTTON_FRIENDLY).strip()
+
+        _LOGGER.debug("Button Configured: %s", display_options_str)
+        
+        self._display_options.append(display_options_str)
+        _LOGGER.debug(
+            "Button Pronto Code: %s - Button Friendly: %s",
+            str(self._button_pronto),
+            str(self._display_options),
+        )
+
+    @property
+    def device_class(self):
+        """Return the class of this device."""
+        return self._config.get(CONF_DEVICE_CLASS)
+
+    async def async_press(self) -> None:
+        """Update the current value."""
+        option_value = self._button_pronto
+        _LOGGER.debug("Sending Option: -> " + option_value)
+
+        pulses = self.pronto_to_pulses(option_value)
+        base64_code = self.pulses_to_base64(pulses)
+
+        await self.send_signal(base64_code)
+        
+    def status_updated(self):
+        """Device status was updated."""
+        super().status_updated()        
+        self._status = self._default_status 
+        self._state_friendly = "Generic Working"
+
+    # Default value is the first option
+    def entity_default_value(self):
+        """Return the first option as the default value for this entity type."""
+        return self._button_pronto
+
+    '''
+    * Here Starts the journy of converting from pronto to a true IR Signal
+    '''
+
+    async def send_signal(self, base64_code):
+        command = {
+            NSDP_CONTROL: "send_ir",
+            NSDP_TYPE: 0,
+        }
+        command[NSDP_HEAD] = ''
+        command[NSDP_KEY1] = '1' + base64_code
+
+        await self._device.set_dp(json.dumps(command), self._default_dp)
+
+    def pronto_to_pulses(self, pronto):
+        ret = [ ]
+        pronto = [int(x, 16) for x in pronto.split(' ')]
+        ptype = pronto[0]
+        timebase = pronto[1]
+        pair1_len = pronto[2]
+        pair2_len = pronto[3]
+        if ptype != 0:
+            # only raw (learned) codes are handled
+            return ret
+        if timebase < 90 or timebase > 139:
+            # only 38 kHz is supported?
+            return ret
+        pronto = pronto[4:]
+        timebase *= 0.241246
+        for i in range(0, pair1_len*2, 2):
+            ret += [round(pronto[i] * timebase), round(pronto[i+1] * timebase)]
+        pronto = pronto[pair1_len*2:]
+        for i in range(0, pair2_len*2, 2):
+            ret += [round(pronto[i] * timebase), round(pronto[i+1] * timebase)]
+        return ret
+
+    def pulses_to_base64(self, pulses):
+        fmt = '<' + str(len(pulses)) + 'H'
+        return base64.b64encode( struct.pack(fmt, *pulses) ).decode("ascii")
+
+
+async_setup_entry = partial(async_setup_entry, DOMAIN, LocaltuyaIRButton, flow_schema)

--- a/custom_components/localtuya/climate.py
+++ b/custom_components/localtuya/climate.py
@@ -13,6 +13,9 @@ from homeassistant.components.climate import (
 from homeassistant.components.climate.const import (
     CURRENT_HVAC_HEAT,
     CURRENT_HVAC_IDLE,
+    HVAC_MODE_COOL, 
+    HVAC_MODE_DRY, 
+    HVAC_MODE_FAN_ONLY,
     HVAC_MODE_AUTO,
     HVAC_MODE_HEAT,
     HVAC_MODE_OFF,
@@ -79,6 +82,20 @@ HVAC_MODE_SETS = {
     "1/0": {
         HVAC_MODE_HEAT: "1",
         HVAC_MODE_AUTO: "0",
+    },
+    "auto/cold/wet/heat/fan": {
+        HVAC_MODE_HEAT: "heat",
+        HVAC_MODE_AUTO: "auto",
+        HVAC_MODE_COOL: "cold",
+        HVAC_MODE_DRY: "wet",
+        HVAC_MODE_FAN_ONLY: "fan",
+    },
+    "auto/cold/wet/hot/wind": {
+        HVAC_MODE_HEAT: "hot",
+        HVAC_MODE_AUTO: "auto",
+        HVAC_MODE_COOL: "cold",
+        HVAC_MODE_DRY: "wet",
+        HVAC_MODE_FAN_ONLY: "wind",
     },
 }
 HVAC_ACTION_SETS = {

--- a/custom_components/localtuya/const.py
+++ b/custom_components/localtuya/const.py
@@ -8,11 +8,12 @@ DATA_CLOUD = "cloud_data"
 # Platforms in this list must support config flows
 PLATFORMS = [
     "binary_sensor",
+    "button",
     "climate",
     "cover",
     "fan",
     "light",
-    "number",
+    "number",    
     "select",
     "sensor",
     "switch",
@@ -128,6 +129,11 @@ CONF_STEPSIZE_VALUE = "step_size"
 # select
 CONF_OPTIONS = "select_options"
 CONF_OPTIONS_FRIENDLY = "select_options_friendly"
+
+# IR Button
+CONF_IR_BUTTON = "ir_pronto_code"
+CONF_IR_BUTTON_FRIENDLY = "ir_button_name"
+CONF_IR_DP_ID = "ir_dp_id"
 
 # States
 ATTR_STATE = "raw_state"

--- a/custom_components/localtuya/strings.json
+++ b/custom_components/localtuya/strings.json
@@ -23,7 +23,7 @@
             },
             "power_outlet": {
                 "title": "Add subswitch",
-		"description": "You are about to add subswitch number `{number}`. If you want to add another, tick `Add another switch` before continuing.",
+                "description": "You are about to add subswitch number `{number}`. If you want to add another, tick `Add another switch` before continuing.",
                 "data": {
                     "id": "ID",
                     "name": "Name",
@@ -101,10 +101,10 @@
                     "fan_speed_min": "minimum fan speed integer",
                     "fan_speed_max": "maximum fan speed integer",
                     "fan_speed_ordered_list": "Fan speed modes list (overrides speed min/max)",
-                    "fan_direction":"fan direction dps",
+                    "fan_direction": "fan direction dps",
                     "fan_direction_forward": "forward dps string",
                     "fan_direction_reverse": "reverse dps string",
-		    "fan_dps_type": "DP value type",
+                    "fan_dps_type": "DP value type",
                     "current_temperature_dp": "Current Temperature",
                     "target_temperature_dp": "Target Temperature",
                     "temperature_step": "Temperature Step (optional)",
@@ -126,7 +126,10 @@
                     "restore_on_reconnect": "Restore the last set value in HomeAssistant after a lost connection",
                     "min_value": "Minimum Value",
                     "max_value": "Maximum Value",
-                    "step_size": "Minimum increment between numbers"
+                    "step_size": "Minimum increment between numbers",
+                    "ir_pronto_code": "Button Code in Pronto format",
+                    "ir_button_name": "User Friendly button name",
+                    "ir_dp_id": "DP Id used to fire IR Signal"
                 }
             },
             "yaml_import": {

--- a/custom_components/localtuya/translations/en.json
+++ b/custom_components/localtuya/translations/en.json
@@ -164,7 +164,7 @@
                     "fan_speed_min": "minimum fan speed integer",
                     "fan_speed_max": "maximum fan speed integer",
                     "fan_speed_ordered_list": "Fan speed modes list (overrides speed min/max)",
-                    "fan_direction":"fan direction dps",
+                    "fan_direction": "fan direction dps",
                     "fan_direction_forward": "forward dps string",
                     "fan_direction_reverse": "reverse dps string",
                     "fan_dps_type": "DP value type",
@@ -190,7 +190,10 @@
                     "min_value": "Minimum Value",
                     "max_value": "Maximum Value",
                     "step_size": "Minimum increment between numbers",
-                    "is_passive_entity": "Passive entity - requires integration to send initialisation value"
+                    "is_passive_entity": "Passive entity - requires integration to send initialisation value",
+                    "ir_pronto_code": "Button Code in Pronto format",
+                    "ir_button_name": "User Friendly button name",
+                    "ir_dp_id": "DP Id used to fire IR Signal"
                 }
             }
         }

--- a/custom_components/localtuya/translations/it.json
+++ b/custom_components/localtuya/translations/it.json
@@ -162,7 +162,7 @@
                     "fan_speed_min": "Velocità del ventilatore minima",
                     "fan_speed_max": "Velocità del ventilatore massima",
                     "fan_speed_ordered_list": "Elenco delle modalità di velocità del ventilatore (sovrascrive velocità min/max)",
-                    "fan_direction":"DP di direzione del ventilatore",
+                    "fan_direction": "DP di direzione del ventilatore",
                     "fan_direction_forward": "Stringa del DP per avanti",
                     "fan_direction_reverse": "Stringa del DP per indietro",
                     "current_temperature_dp": "Temperatura attuale",
@@ -181,7 +181,10 @@
                     "preset_set": "Set di preset (opzionale)",
                     "eco_dp": "DP per Eco (opzionale)",
                     "eco_value": "Valore Eco (opzionale)",
-                    "heuristic_action": "Abilita azione euristica (opzionale)"
+                    "heuristic_action": "Abilita azione euristica (opzionale)",
+                    "ir_pronto_code": "Codice pulsante in formato Pronto",
+                    "ir_button_name": "Nome pulsante intuitivo",
+                    "ir_dp_id": "ID DP utilizzato per attivare il segnale IR"
                 }
             }
         }

--- a/custom_components/localtuya/translations/pt-BR.json
+++ b/custom_components/localtuya/translations/pt-BR.json
@@ -162,7 +162,7 @@
                     "fan_speed_min": "Velocidade mínima do ventilador inteiro",
                     "fan_speed_max": "Velocidade máxima do ventilador inteiro",
                     "fan_speed_ordered_list": "Lista de modos de velocidade do ventilador (substitui a velocidade min/max)",
-                    "fan_direction":"Direção do ventilador dps",
+                    "fan_direction": "Direção do ventilador dps",
                     "fan_direction_forward": "Seqüência de dps para frente",
                     "fan_direction_reverse": "String dps reversa",
                     "current_temperature_dp": "Temperatura atual",
@@ -181,7 +181,10 @@
                     "preset_set": "Conjunto de predefinições (opcional)",
                     "eco_dp": "Eco DP (opcional)",
                     "eco_value": "Valor eco (opcional)",
-                    "heuristic_action": "Ativar ação heurística (opcional)"
+                    "heuristic_action": "Ativar ação heurística (opcional)",
+                    "ir_pronto_code": "Código Pronto do botão",
+                    "ir_button_name": "Nome do botão",
+                    "ir_dp_id": "DP Utilizado para disparar o sinal"
                 }
             }
         }


### PR DESCRIPTION
## IR Control
After some research and a long analysis of the way that Tuya comunicates with generic IR Controls, I've found [this discussion](https://github.com/jasonacox/tinytuya/issues/74) at TinyTuya repo that lead me to that integration. 

Some parts of code, like the convertions of signal was taken from there.

For now it is a very basic implementation using the Button entity, as Tuya doesn't provide informations about the registered buttons, is necessary that the user configure the device Key by Key into HASS using the Pronto Code of corresponding Key.

The signal sent by Tuya uses de DP_ID 201, as the device doesn't have a default status, was necessary create a bypass for status checking, so HASS doesn't consider the device unavaliable and to this works propertely, the user needs to input manual DPs for each Key that it's have. 

Ex:
The user wants to configure 5 keys, it has to add 5 DPs numbers, as 1 to 5, so the Config Flow can provide the option for add new entities into device for the user.

Another limitation is that ALL keys mus use the DP 201, so I've added a new field to user defines de DP for blast the signal, ignoring provided DPs in first config screen.

For a better implementation, would be nice to reuse the DP to add new entities; Expand the compatibility of IR Controls, identifying the control version, as described into TinyTuya topic; Group all keys of a gadget, today all keys be part of the device.

Some Issues/Requests related to IR Control:
#670 #882 #557 

### Resume

- [x] Support for IR Controls
- [ ] Reuse DPs
- [ ] Group keys by gadget
- [ ] Expand compatibility

## Climate

As described at #1115, there are missing some HVAC_MODE, so I've added a new one besides that described in the issue.