### PR TITLE
added self._connect_task.done() check to async_connect

### DIFF
--- a/custom_components/localtuya/common.py
+++ b/custom_components/localtuya/common.py
@@ -176,7 +176,7 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
 
     def async_connect(self):
         """Connect to device if not already connected."""
-        if not self._is_closing and self._connect_task is None and not self._interface:
+        if not self._is_closing and (self._connect_task is None or self._connect_task.done()) and not self._interface:
             self._connect_task = asyncio.create_task(self._make_connection())
 
     async def _make_connection(self):


### PR DESCRIPTION
My bulbs got stuck in an offline state, when they were power cycled.

The issue was, that the _make_connection method must have returned or raised an exception after the bulbs were powered off. Therefore, the line "self._connect_task = None" at the end of the _make_connection method was never reached, the object will never get deleted and no new connection will ever be established when the device is powered on again.

I think the line [170](https://github.com/rospogrigio/localtuya/blob/98cc44fcd1403ac6eb3daef0da1452995ac86ab0/custom_components/localtuya/common.py#L170) hast to be changed also. But I'm not 100% sure.