### PR TITLE
Label DPs with cloud API descriptions if available

### DIFF
--- a/custom_components/localtuya/cloud_api.py
+++ b/custom_components/localtuya/cloud_api.py
@@ -134,3 +134,18 @@ class TuyaCloudApi:
         # _LOGGER.debug("DEV_LIST: %s", self.device_list)
 
         return "ok"
+
+    async def async_get_device_specifications(self, device_id):
+        """Obtain the DP ID mappings for a device."""
+        resp = await self.async_make_request(
+            "GET", url=f"/v1.1/devices/{device_id}/specifications"
+        )
+
+        if not resp.ok:
+            return {}, "Request failed, status " + str(resp.status)
+
+        r_json = resp.json()
+        if not r_json["success"]:
+            return {}, f"Error {r_json['code']}: {r_json['msg']}"
+
+        return r_json["result"], "ok"


### PR DESCRIPTION
The Tuya cloud Get Device Specification Attribute API provides a name for most DPs for most devices. When configuring a device, include that name if it's available.

![Screenshot from 2023-01-21 10-48-51](https://user-images.githubusercontent.com/806600/213824848-6f034fab-10ae-4a1c-be62-119ecfb28a3b.png)
