### PR TITLE
Force to int to avoid  TypeError: '>' not supported between instances of 'str' and 'int' after editing entity.

### DIFF
--- a/custom_components/localtuya/common.py
+++ b/custom_components/localtuya/common.py
@@ -270,7 +270,7 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
 
             if (
                 CONF_SCAN_INTERVAL in self._dev_config_entry
-                and self._dev_config_entry[CONF_SCAN_INTERVAL] > 0
+                and int(self._dev_config_entry[CONF_SCAN_INTERVAL]) > 0
             ):
                 self._unsub_interval = async_track_time_interval(
                     self._hass,

--- a/custom_components/localtuya/common.py
+++ b/custom_components/localtuya/common.py
@@ -275,7 +275,7 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
                 self._unsub_interval = async_track_time_interval(
                     self._hass,
                     self._async_refresh,
-                    timedelta(seconds=self._dev_config_entry[CONF_SCAN_INTERVAL]),
+                    timedelta(seconds=int(self._dev_config_entry[CONF_SCAN_INTERVAL])),
                 )
 
         self._connect_task = None

--- a/custom_components/localtuya/config_flow.py
+++ b/custom_components/localtuya/config_flow.py
@@ -140,7 +140,7 @@ def options_schema(entities):
                 ["3.1", "3.2", "3.3", "3.4"]
             ),
             vol.Required(CONF_ENABLE_DEBUG, default=False): bool,
-            vol.Optional(CONF_SCAN_INTERVAL): cv.string,
+            vol.Optional(CONF_SCAN_INTERVAL): cv.int,
             vol.Optional(CONF_MANUAL_DPS): cv.string,
             vol.Optional(CONF_RESET_DPIDS): cv.string,
             vol.Required(

--- a/custom_components/localtuya/config_flow.py
+++ b/custom_components/localtuya/config_flow.py
@@ -140,7 +140,7 @@ def options_schema(entities):
                 ["3.1", "3.2", "3.3", "3.4"]
             ),
             vol.Required(CONF_ENABLE_DEBUG, default=False): bool,
-            vol.Optional(CONF_SCAN_INTERVAL): cv.int,
+            vol.Optional(CONF_SCAN_INTERVAL): int,
             vol.Optional(CONF_MANUAL_DPS): cv.string,
             vol.Optional(CONF_RESET_DPIDS): cv.string,
             vol.Required(


### PR DESCRIPTION
Regression introduced in 33e0033b0a95003252779262e58a719a902c4d1e - accidentally refactored int to str

Fixes https://github.com/rospogrigio/localtuya/issues/1258
Fixes https://github.com/rospogrigio/localtuya/issues/1248
Supercedes #1251 (Partially)


Error unloading entry localtuya for localtuya
Traceback (most recent call last):
File "/usr/src/homeassistant/homeassistant/config_entries.py", line 533, in async_unload
result = await component.async_unload_entry(hass, self)
File "/config/custom_components/localtuya/init.py", line 311, in async_unload_entry
await device.close()
File "/config/custom_components/localtuya/common.py", line 308, in close
await self._connect_task
File "/config/custom_components/localtuya/common.py", line 273, in _make_connection
and self._dev_config_entry[CONF_SCAN_INTERVAL] > 0
TypeError: '>' not supported between instances of 'str' and 'int'