### PR TITLE
added number type config

### DIFF
--- a/custom_components/localtuya/const.py
+++ b/custom_components/localtuya/const.py
@@ -125,6 +125,7 @@ CONF_STOP_STATUS = "stop_status"
 CONF_MIN_VALUE = "min_value"
 CONF_MAX_VALUE = "max_value"
 CONF_STEPSIZE_VALUE = "step_size"
+CONF_VALUE_TYPE = "value_type"
 
 # select
 CONF_OPTIONS = "select_options"

--- a/custom_components/localtuya/number.py
+++ b/custom_components/localtuya/number.py
@@ -14,6 +14,7 @@ from .const import (
     CONF_PASSIVE_ENTITY,
     CONF_RESTORE_ON_RECONNECT,
     CONF_STEPSIZE_VALUE,
+    CONF_VALUE_TYPE
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -41,6 +42,7 @@ def flow_schema(dps):
         vol.Required(CONF_RESTORE_ON_RECONNECT): bool,
         vol.Required(CONF_PASSIVE_ENTITY): bool,
         vol.Optional(CONF_DEFAULT_VALUE): str,
+        vol.Optional(CONF_VALUE_TYPE, default="float"): vol.In(["float", "int"]),
     }
 
 
@@ -102,7 +104,8 @@ class LocaltuyaNumber(LocalTuyaEntity, NumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
-        await self._device.set_dp(value, self._dp_id)
+        send_value = int(value) if self._config.get(CONF_VALUE_TYPE) == "int" else value
+        await self._device.set_dp(send_value, self._dp_id)
 
     # Default value is the minimum value
     def entity_default_value(self):


### PR DESCRIPTION
Some devices need number values in certain formats. For example, I have a dehumidifier which takes a target humidity, but only as an integer. If we send the value as float, it just doesn't do anything...

To solve that, I have added a type selection for the number platform which defaults to the old default behaviour "float" and can optionally be set to "int".