### PR TITLE
Fix reset behaviour for configured devices

### DIFF
--- a/custom_components/localtuya/common.py
+++ b/custom_components/localtuya/common.py
@@ -201,7 +201,7 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
 
         if self._interface is not None:
             try:
-                #If reset dpids set - then assume reset is needed before status.
+                # If reset dpids set - then assume reset is needed before status.
                 if (self._default_reset_dpids is not None) and (
                     len(self._default_reset_dpids) > 0
                 ):
@@ -209,10 +209,10 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
                         "Resetting command for DP IDs: %s",
                         self._default_reset_dpids,
                     )
-                    #Assume we want to request status updated for the same set of DP_IDs as the reset ones.
+                    # Assume we want to request status updated for the same set of DP_IDs as the reset ones.
                     self._interface.set_updatedps_list(self._default_reset_dpids)
 
-                    #Reset the interface
+                    # Reset the interface
                     await self._interface.reset(self._default_reset_dpids)
 
                 self.debug("Retrieving initial state")
@@ -233,9 +233,7 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
                     self._interface = None
 
             except Exception as e:  # pylint: disable=broad-except
-                self.exception(
-                    f"Connect to {self._dev_config_entry[CONF_HOST]} failed"
-                )
+                self.exception(f"Connect to {self._dev_config_entry[CONF_HOST]} failed")
                 if "json.decode" in str(type(e)):
                     await self.update_local_key()
 

--- a/custom_components/localtuya/config_flow.py
+++ b/custom_components/localtuya/config_flow.py
@@ -255,16 +255,25 @@ async def validate_input(hass: core.HomeAssistant, data):
                 reset_ids,
             )
         try:
+            #If reset dpids set - then assume reset is needed before status.
+            if (reset_ids is not None) and (
+                len(reset_ids) > 0
+            ):
+                self.debug(
+                    "Resetting command for DP IDs: %s",
+                    reset_ids,
+                )
+                #Assume we want to request status updated for the same set of DP_IDs as the reset ones.
+                interface.set_updatedps_list(reset_ids)
+
+                #Reset the interface
+                await interface.reset(reset_ids)
+
+            #Detect any other non-manual DPS strings
             detected_dps = await interface.detect_available_dps()
         except Exception:  # pylint: disable=broad-except
-            try:
-                _LOGGER.debug("Initial state update failed, trying reset command")
-                if len(reset_ids) > 0:
-                    await interface.reset(reset_ids)
-                    detected_dps = await interface.detect_available_dps()
-            except Exception:  # pylint: disable=broad-except
-                _LOGGER.debug("No DPS able to be detected")
-                detected_dps = {}
+            _LOGGER.debug("No DPS able to be detected")
+            detected_dps = {}
 
         # if manual DPs are set, merge these.
         _LOGGER.debug("Detected DPS: %s", detected_dps)

--- a/custom_components/localtuya/config_flow.py
+++ b/custom_components/localtuya/config_flow.py
@@ -255,21 +255,19 @@ async def validate_input(hass: core.HomeAssistant, data):
                 reset_ids,
             )
         try:
-            #If reset dpids set - then assume reset is needed before status.
-            if (reset_ids is not None) and (
-                len(reset_ids) > 0
-            ):
-                self.debug(
+            # If reset dpids set - then assume reset is needed before status.
+            if (reset_ids is not None) and (len(reset_ids) > 0):
+                _LOGGER.debug(
                     "Resetting command for DP IDs: %s",
                     reset_ids,
                 )
-                #Assume we want to request status updated for the same set of DP_IDs as the reset ones.
+                # Assume we want to request status updated for the same set of DP_IDs as the reset ones.
                 interface.set_updatedps_list(reset_ids)
 
-                #Reset the interface
+                # Reset the interface
                 await interface.reset(reset_ids)
 
-            #Detect any other non-manual DPS strings
+            # Detect any other non-manual DPS strings
             detected_dps = await interface.detect_available_dps()
         except Exception:  # pylint: disable=broad-except
             _LOGGER.debug("No DPS able to be detected")

--- a/custom_components/localtuya/pytuya/__init__.py
+++ b/custom_components/localtuya/pytuya/__init__.py
@@ -511,12 +511,6 @@ class MessageDispatcher(ContextualLogger):
                 else:
                     self.debug("Got additional reset message without request - skipping: %s", sem)
             else:
-                if isinstance(sem, asyncio.Semaphore):
-                    self.listeners[self.RESET_SEQNO] = msg
-                    sem.release()
-                else:
-                    self.debug("Got additional reset message without request - skipping: %s", sem)
-            else:
                 self.debug("Got status update")
                 self.listener(msg)
         else:

--- a/custom_components/localtuya/pytuya/__init__.py
+++ b/custom_components/localtuya/pytuya/__init__.py
@@ -490,8 +490,11 @@ class MessageDispatcher(ContextualLogger):
             self.debug("Got normal updatedps response")
             if self.RESET_SEQNO in self.listeners:
                 sem = self.listeners[self.RESET_SEQNO]
-                self.listeners[self.RESET_SEQNO] = msg
-                sem.release()
+                if isinstance(sem, asyncio.Semaphore):
+                    self.listeners[self.RESET_SEQNO] = msg
+                    sem.release()
+                else:
+                    self.debug("Got additional updatedps message without request - skipping: %s", sem)
         elif msg.cmd == SESS_KEY_NEG_RESP:
             self.debug("Got key negotiation response")
             if self.SESS_KEY_SEQNO in self.listeners:
@@ -502,6 +505,12 @@ class MessageDispatcher(ContextualLogger):
             if self.RESET_SEQNO in self.listeners:
                 self.debug("Got reset status update")
                 sem = self.listeners[self.RESET_SEQNO]
+                if isinstance(sem, asyncio.Semaphore):
+                    self.listeners[self.RESET_SEQNO] = msg
+                    sem.release()
+                else:
+                    self.debug("Got additional reset message without request - skipping: %s", sem)
+            else:
                 if isinstance(sem, asyncio.Semaphore):
                     self.listeners[self.RESET_SEQNO] = msg
                     sem.release()

--- a/custom_components/localtuya/pytuya/__init__.py
+++ b/custom_components/localtuya/pytuya/__init__.py
@@ -494,7 +494,10 @@ class MessageDispatcher(ContextualLogger):
                     self.listeners[self.RESET_SEQNO] = msg
                     sem.release()
                 else:
-                    self.debug("Got additional updatedps message without request - skipping: %s", sem)
+                    self.debug(
+                        "Got additional updatedps message without request - skipping: %s",
+                        sem,
+                    )
         elif msg.cmd == SESS_KEY_NEG_RESP:
             self.debug("Got key negotiation response")
             if self.SESS_KEY_SEQNO in self.listeners:
@@ -509,7 +512,10 @@ class MessageDispatcher(ContextualLogger):
                     self.listeners[self.RESET_SEQNO] = msg
                     sem.release()
                 else:
-                    self.debug("Got additional reset message without request - skipping: %s", sem)
+                    self.debug(
+                        "Got additional reset message without request - skipping: %s",
+                        sem,
+                    )
             else:
                 self.debug("Got status update")
                 self.listener(msg)

--- a/custom_components/localtuya/pytuya/__init__.py
+++ b/custom_components/localtuya/pytuya/__init__.py
@@ -810,8 +810,9 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
             return await self.exchange(UPDATEDPS, dpIds)
 
         return True
+
     def set_updatedps_list(self, update_list):
-        """Set the DPS to be requested with the update command"""
+        """Set the DPS to be requested with the update command."""
         self.dps_whitelist = update_list
 
     async def update_dps(self, dps=None):

--- a/custom_components/localtuya/pytuya/__init__.py
+++ b/custom_components/localtuya/pytuya/__init__.py
@@ -502,8 +502,11 @@ class MessageDispatcher(ContextualLogger):
             if self.RESET_SEQNO in self.listeners:
                 self.debug("Got reset status update")
                 sem = self.listeners[self.RESET_SEQNO]
-                self.listeners[self.RESET_SEQNO] = msg
-                sem.release()
+                if isinstance(sem, asyncio.Semaphore):
+                    self.listeners[self.RESET_SEQNO] = msg
+                    sem.release()
+                else:
+                    self.debug("Got additional reset message without request - skipping: %s", sem)
             else:
                 self.debug("Got status update")
                 self.listener(msg)
@@ -584,6 +587,7 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
         self.dps_cache = {}
         self.local_nonce = b"0123456789abcdef"  # not-so-random random key
         self.remote_nonce = b""
+        self.dps_whitelist = UPDATE_DPS_WHITELIST
 
     def set_version(self, protocol_version):
         """Set the device version and eventually start available DPs detection."""
@@ -803,6 +807,9 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
             return await self.exchange(UPDATEDPS, dpIds)
 
         return True
+    def set_updatedps_list(self, update_list):
+        """Set the DPS to be requested with the update command"""
+        self.dps_whitelist = update_list
 
     async def update_dps(self, dps=None):
         """
@@ -818,7 +825,7 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
                 if self.dps_cache:
                     dps = [int(dp) for dp in self.dps_cache]
                     # filter non whitelisted dps
-                    dps = list(set(dps).intersection(set(UPDATE_DPS_WHITELIST)))
+                    dps = list(set(dps).intersection(set(self.dps_whitelist)))
             self.debug("updatedps() entry (dps %s, dps_cache %s)", dps, self.dps_cache)
             payload = self._generate_payload(UPDATEDPS, dps)
             enc_payload = self._encode_message(payload)


### PR DESCRIPTION
For devices configured with IDs to be sent with a RESET command, fix the logic. When i made the RESET logic less aggressive, I made the code only send it if no DPIDs were detected. However some devices (like power plugs), will present a DPID of 1 (the main switch), but not the additional power sensor DPIDs. The previous logic would never then trigger a RESET which would expose those additional DPIDs. This logic fixes that issue.

@rospogrigio - as discussed in PR #1087. This code stands separate from that one. I've tested this week and all appears to be functioning correctly on my system.