### PR TITLE
Added new hvac mode set for handling Plikc Smart Thermostats modesets

### DIFF
--- a/custom_components/localtuya/climate.py
+++ b/custom_components/localtuya/climate.py
@@ -80,6 +80,12 @@ HVAC_MODE_SETS = {
         HVAC_MODE_HEAT: "1",
         HVAC_MODE_AUTO: "0",
     },
+    "manual/auto/holiday/temporary": {
+        HVAC_MODE_HEAT: "manual",
+        HVAC_MODE_AUTO: "auto",
+        HVAC_MODE_HOLIDAY: "holiday",
+        HVAC_MODE_TEMPORARY: "temporary",
+    },
 }
 HVAC_ACTION_SETS = {
     "True/False": {


### PR DESCRIPTION
In order to correcty handle "Plikc Smart" thermostat statuses, I added a new hvac mode set with 2 more other statuses:
1. Holiday
2. Temporary.

We need to manage this statuses requesting 2 new more attributes related to them:
1. The remaining for "Holiday" time ("code": "holiday_days_set") in days.
2.The remaining  for "Temporary" time ("code": "countdown_left") in minutes 

Sorry but I don't have enough information about how to implements these two new attributes and handling the change status event for request them.