### PR TITLE
Adding support for local sub-devices (nodes)

### DIFF
--- a/custom_components/localtuya/common.py
+++ b/custom_components/localtuya/common.py
@@ -31,6 +31,7 @@ from .const import (
     CONF_DEFAULT_VALUE,
     CONF_ENABLE_DEBUG,
     CONF_LOCAL_KEY,
+    CONF_DEVICE_NODE_ID,
     CONF_MODEL,
     CONF_PASSIVE_ENTITY,
     CONF_PROTOCOL_VERSION,
@@ -192,6 +193,7 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
                 self._local_key,
                 float(self._dev_config_entry[CONF_PROTOCOL_VERSION]),
                 self._dev_config_entry.get(CONF_ENABLE_DEBUG, False),
+                self._dev_config_entry[CONF_DEVICE_NODE_ID],
                 self,
             )
             self._interface.add_dps_to_request(self.dps_to_request)

--- a/custom_components/localtuya/config_flow.py
+++ b/custom_components/localtuya/config_flow.py
@@ -35,6 +35,7 @@ from .const import (
     CONF_EDIT_DEVICE,
     CONF_ENABLE_DEBUG,
     CONF_LOCAL_KEY,
+    CONF_DEVICE_NODE_ID,
     CONF_MANUAL_DPS,
     CONF_MODEL,
     CONF_NO_CLOUD,
@@ -89,6 +90,7 @@ DEVICE_SCHEMA = vol.Schema(
         vol.Required(CONF_FRIENDLY_NAME): cv.string,
         vol.Required(CONF_HOST): cv.string,
         vol.Required(CONF_DEVICE_ID): cv.string,
+        vol.Optional(CONF_DEVICE_NODE_ID): cv.string,
         vol.Required(CONF_LOCAL_KEY): cv.string,
         vol.Required(CONF_PROTOCOL_VERSION, default="3.3"): vol.In(
             ["3.1", "3.2", "3.3", "3.4"]
@@ -243,6 +245,7 @@ async def validate_input(hass: core.HomeAssistant, data):
             data[CONF_LOCAL_KEY],
             float(data[CONF_PROTOCOL_VERSION]),
             data[CONF_ENABLE_DEBUG],
+            data[CONF_DEVICE_NODE_ID],
         )
         if CONF_RESET_DPIDS in data:
             reset_ids_str = data[CONF_RESET_DPIDS].split(",")
@@ -613,6 +616,7 @@ class LocalTuyaOptionsFlowHandler(config_entries.OptionsFlow):
             defaults[CONF_PROTOCOL_VERSION] = "3.3"
             defaults[CONF_HOST] = ""
             defaults[CONF_DEVICE_ID] = ""
+            defaults[CONF_DEVICE_NODE_ID] = ""
             defaults[CONF_LOCAL_KEY] = ""
             defaults[CONF_FRIENDLY_NAME] = ""
             if dev_id is not None:
@@ -620,6 +624,7 @@ class LocalTuyaOptionsFlowHandler(config_entries.OptionsFlow):
                 device = self.discovered_devices[dev_id]
                 defaults[CONF_HOST] = device.get("ip")
                 defaults[CONF_DEVICE_ID] = device.get("gwId")
+                defaults[CONF_DEVICE_NODE_ID] = device.get("cid")
                 defaults[CONF_PROTOCOL_VERSION] = device.get("version")
                 cloud_devs = self.hass.data[DOMAIN][DATA_CLOUD].device_list
                 if dev_id in cloud_devs:

--- a/custom_components/localtuya/const.py
+++ b/custom_components/localtuya/const.py
@@ -28,6 +28,7 @@ ATTR_UPDATED_AT = "updated_at"
 
 # config flow
 CONF_LOCAL_KEY = "local_key"
+CONF_DEVICE_NODE_ID = "device_node_id"
 CONF_ENABLE_DEBUG = "enable_debug"
 CONF_PROTOCOL_VERSION = "protocol_version"
 CONF_DPS_STRINGS = "dps_strings"

--- a/custom_components/localtuya/pytuya/__init__.py
+++ b/custom_components/localtuya/pytuya/__init__.py
@@ -186,14 +186,14 @@ payload_dict = {
             "command": {"gwId": "", "devId": "", "uid": "", "t": ""},
         },
         CONTROL: {  # Set Control Values on Device
-            "command": {"devId": "", "uid": "", "t": ""},
+            "command": {"devId": "", "uid": "", "t": "", "cid": ""},
         },
         STATUS: {  # Get Status from Device
-            "command": {"gwId": "", "devId": ""},
+            "command": {"gwId": "", "devId": "", "cid": ""},
         },
         HEART_BEAT: {"command": {"gwId": "", "devId": ""}},
         DP_QUERY: {  # Get Data Points from Device
-            "command": {"gwId": "", "devId": "", "uid": "", "t": ""},
+            "command": {"gwId": "", "devId": "", "uid": "", "t": "", "cid": ""},
         },
         CONTROL_NEW: {"command": {"devId": "", "uid": "", "t": ""}},
         DP_QUERY_NEW: {"command": {"devId": "", "uid": "", "t": ""}},
@@ -205,7 +205,7 @@ payload_dict = {
     "type_0d": {
         DP_QUERY: {  # Get Data Points from Device
             "command_override": CONTROL_NEW,  # Uses CONTROL_NEW command for some reason
-            "command": {"devId": "", "uid": "", "t": ""},
+            "command": {"devId": "", "uid": "", "t": "", "cid": ""},
         },
     },
     "v3.4": {
@@ -551,7 +551,14 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
     """Implementation of the Tuya protocol."""
 
     def __init__(
-        self, dev_id, local_key, protocol_version, enable_debug, on_connected, listener
+        self,
+        dev_id,
+        local_key,
+        node_id,
+        protocol_version,
+        enable_debug,
+        on_connected,
+        listener,
     ):
         """
         Initialize a new TuyaInterface.
@@ -568,6 +575,7 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
         self.loop = asyncio.get_running_loop()
         self.set_logger(_LOGGER, dev_id, enable_debug)
         self.id = dev_id
+        self.node_id = node_id
         self.local_key = local_key.encode("latin1")
         self.real_local_key = self.local_key
         self.dev_type = "type_0a"
@@ -621,6 +629,8 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
                 self.seqno = msg.seqno + 1
             decoded_message = self._decode_payload(msg.payload)
             if "dps" in decoded_message:
+                if "cid" in decoded_message and decoded_message["cid"] != self.node_id:
+                    return
                 self.dps_cache.update(decoded_message["dps"])
 
             listener = self.listener and self.listener()
@@ -851,8 +861,18 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
         # list of available dps experience shows that the dps available are usually
         # in the ranges [1-25] and [100-110] need to split the bruteforcing in
         # different steps due to request payload limitation (max. length = 255)
+        # added a few more ranges discovered for Holman WX1 and WX2 tap timers
         self.dps_cache = {}
-        ranges = [(2, 11), (11, 21), (21, 31), (100, 111)]
+        ranges = [
+            (2, 11),
+            (11, 21),
+            (21, 31),
+            (100, 110),
+            (111, 121),
+            (122, 130),
+            (150, 160),
+            (161, 170),
+        ]
 
         for dps_range in ranges:
             # dps 1 must always be sent, otherwise it might fail in case no dps is found
@@ -1066,7 +1086,9 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
         # self.debug("payload encrypted with key %r => %r", self.local_key, binascii.hexlify(buffer))
         return buffer
 
-    def _generate_payload(self, command, data=None, gwId=None, devId=None, uid=None):
+    def _generate_payload(
+        self, command, data=None, gwId=None, devId=None, uid=None, nodeId=None
+    ):
         """
         Generate the payload to send.
 
@@ -1083,11 +1105,11 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
 
         if command in payload_dict[self.dev_type]:
             if "command" in payload_dict[self.dev_type][command]:
-                json_data = payload_dict[self.dev_type][command]["command"]
+                json_data = payload_dict[self.dev_type][command]["command"].copy()
             if "command_override" in payload_dict[self.dev_type][command]:
                 command_override = payload_dict[self.dev_type][command][
                     "command_override"
-                ]
+                ].copy()
 
         if self.dev_type != "type_0a":
             if (
@@ -1095,20 +1117,22 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
                 and command in payload_dict["type_0a"]
                 and "command" in payload_dict["type_0a"][command]
             ):
-                json_data = payload_dict["type_0a"][command]["command"]
+                json_data = payload_dict["type_0a"][command]["command"].copy()
             if (
                 command_override is None
                 and command in payload_dict["type_0a"]
                 and "command_override" in payload_dict["type_0a"][command]
             ):
-                command_override = payload_dict["type_0a"][command]["command_override"]
+                command_override = payload_dict["type_0a"][command][
+                    "command_override"
+                ].copy()
 
         if command_override is None:
             command_override = command
         if json_data is None:
             # I have yet to see a device complain about included but unneeded attribs, but they *will*
             # complain about missing attribs, so just include them all unless otherwise specified
-            json_data = {"gwId": "", "devId": "", "uid": "", "t": ""}
+            json_data = {"gwId": "", "devId": "", "uid": "", "t": "", "cid": ""}
 
         if "gwId" in json_data:
             if gwId is not None:
@@ -1125,6 +1149,18 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
                 json_data["uid"] = uid
             else:
                 json_data["uid"] = self.id
+        if "cid" in json_data:
+            if nodeId is not None:
+                json_data["cid"] = nodeId
+                json_data["devId"] = nodeId
+            elif self.node_id != "" and self.node_id is not None:
+                json_data["cid"] = self.node_id
+                # The devId needs to be the nodeId, not the actual devId for
+                # subdevices to work.
+                json_data["devId"] = self.node_id
+            else:
+                # don't send cid for non-subdevices
+                del json_data["cid"]
         if "t" in json_data:
             if json_data["t"] == "int":
                 json_data["t"] = int(time.time())
@@ -1162,6 +1198,7 @@ async def connect(
     local_key,
     protocol_version,
     enable_debug,
+    node_id=None,
     listener=None,
     port=6668,
     timeout=5,
@@ -1173,6 +1210,7 @@ async def connect(
         lambda: TuyaProtocol(
             device_id,
             local_key,
+            node_id,
             protocol_version,
             enable_debug,
             on_connected,

--- a/custom_components/localtuya/translations/en.json
+++ b/custom_components/localtuya/translations/en.json
@@ -94,6 +94,7 @@
                     "friendly_name": "Name",
                     "host": "Host",
                     "device_id": "Device ID",
+                    "device_node_id": "Sub Device Node ID",
                     "local_key": "Local key",
                     "protocol_version": "Protocol Version",
                     "enable_debug": "Enable debugging for this device (debug must be enabled also in configuration.yaml)",

--- a/custom_components/localtuya/translations/it.json
+++ b/custom_components/localtuya/translations/it.json
@@ -94,6 +94,7 @@
                     "friendly_name": "Nome",
                     "host": "Host",
                     "device_id": "ID del dispositivo",
+                    "device_node_id": "Node ID del dispositivo (sub-device)",
                     "local_key": "Chiave locale",
                     "protocol_version": "Versione del protocollo",
                     "enable_debug": "Abilita il debugging per questo device (il debug va abilitato anche in configuration.yaml)",

--- a/custom_components/localtuya/translations/pt-BR.json
+++ b/custom_components/localtuya/translations/pt-BR.json
@@ -94,6 +94,7 @@
                     "friendly_name": "Nome",
                     "host": "Host",
                     "device_id": "ID do dispositivo",
+                    "device_node_id": "Node ID do dispositivo (sub-device)",
                     "local_key": "Local key",
                     "protocol_version": "Versão do protocolo",
                     "enable_debug": "Ative a depuração para este dispositivo (a depuração também deve ser ativada em configuration.yaml)",


### PR DESCRIPTION
Adding support to configure subdevices by their node ID. Added node ID as an optional parameter when connecting devices. Additional fixes:
Add more dps ranges from devices I have seen.
Copy json_data instead of assigning it, so that the payload dictionary doesn't get written to. Otherwise, values from other devices may be sent during exchange.