### PR TITLE
Fix reset behaviour (with history fixed)

### DIFF
--- a/custom_components/localtuya/common.py
+++ b/custom_components/localtuya/common.py
@@ -1,6 +1,5 @@
 """Code shared between all platforms."""
 import asyncio
-import json.decoder
 import logging
 import time
 from datetime import timedelta

--- a/custom_components/localtuya/common.py
+++ b/custom_components/localtuya/common.py
@@ -205,42 +205,43 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
 
         if self._interface is not None:
             try:
-                try:
-                    self.debug("Retrieving initial state")
-                    status = await self._interface.status()
-                    if status is None:
-                        raise Exception("Failed to retrieve status")
+                #If reset dpids set - then assume reset is needed before status.
+                if (self._default_reset_dpids is not None) and (
+                    len(self._default_reset_dpids) > 0
+                ):
+                    self.debug(
+                        "Resetting command for DP IDs: %s",
+                        self._default_reset_dpids,
+                    )
+                    #Assume we want to request status updated for the same set of DP_IDs as the reset ones.
+                    self._interface.set_updatedps_list(self._default_reset_dpids)
 
-                    self._interface.start_heartbeat()
-                    self.status_updated(status)
+                    #Reset the interface
+                    await self._interface.reset(self._default_reset_dpids)
 
-                except Exception as ex:
-                    if (self._default_reset_dpids is not None) and (
-                        len(self._default_reset_dpids) > 0
-                    ):
-                        self.debug(
-                            "Initial state update failed, trying reset command "
-                            + "for DP IDs: %s",
-                            self._default_reset_dpids,
-                        )
-                        await self._interface.reset(self._default_reset_dpids)
+                self.debug("Retrieving initial state")
+                status = await self._interface.status()
+                if status is None:
+                    raise Exception("Failed to retrieve status")
 
-                        self.debug("Update completed, retrying initial state")
-                        status = await self._interface.status()
-                        if status is None or not status:
-                            raise Exception("Failed to retrieve status") from ex
+                self._interface.start_heartbeat()
+                self.status_updated(status)
 
-                        self._interface.start_heartbeat()
-                        self.status_updated(status)
-                    else:
-                        self.error("Initial state update failed, giving up: %r", ex)
-                        if self._interface is not None:
-                            await self._interface.close()
-                            self._interface = None
+            except UnicodeDecodeError as e:  # pylint: disable=broad-except
+                self.exception(
+                    f"Connect to {self._dev_config_entry[CONF_HOST]} failed: %s",
+                    type(e),
+                )
+                if self._interface is not None:
+                    await self._interface.close()
+                    self._interface = None
 
-            except (UnicodeDecodeError, json.decoder.JSONDecodeError) as ex:
-                self.warning("Initial state update failed (%s), trying key update", ex)
-                await self.update_local_key()
+            except Exception as e:  # pylint: disable=broad-except
+                self.exception(
+                    f"Connect to {self._dev_config_entry[CONF_HOST]} failed"
+                )
+                if "json.decode" in str(type(e)):
+                    await self.update_local_key()
 
                 if self._interface is not None:
                     await self._interface.close()
@@ -297,6 +298,7 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
 
     async def _async_refresh(self, _now):
         if self._interface is not None:
+            self.debug("Refreshing dps for device")
             await self._interface.update_dps()
 
     async def close(self):

--- a/custom_components/localtuya/common.py
+++ b/custom_components/localtuya/common.py
@@ -205,7 +205,7 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
 
         if self._interface is not None:
             try:
-                #If reset dpids set - then assume reset is needed before status.
+                # If reset dpids set - then assume reset is needed before status.
                 if (self._default_reset_dpids is not None) and (
                     len(self._default_reset_dpids) > 0
                 ):
@@ -213,10 +213,10 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
                         "Resetting command for DP IDs: %s",
                         self._default_reset_dpids,
                     )
-                    #Assume we want to request status updated for the same set of DP_IDs as the reset ones.
+                    # Assume we want to request status updated for the same set of DP_IDs as the reset ones.
                     self._interface.set_updatedps_list(self._default_reset_dpids)
 
-                    #Reset the interface
+                    # Reset the interface
                     await self._interface.reset(self._default_reset_dpids)
 
                 self.debug("Retrieving initial state")
@@ -237,9 +237,7 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
                     self._interface = None
 
             except Exception as e:  # pylint: disable=broad-except
-                self.exception(
-                    f"Connect to {self._dev_config_entry[CONF_HOST]} failed"
-                )
+                self.exception(f"Connect to {self._dev_config_entry[CONF_HOST]} failed")
                 if "json.decode" in str(type(e)):
                     await self.update_local_key()
 

--- a/custom_components/localtuya/config_flow.py
+++ b/custom_components/localtuya/config_flow.py
@@ -255,21 +255,19 @@ async def validate_input(hass: core.HomeAssistant, data):
                 reset_ids,
             )
         try:
-            #If reset dpids set - then assume reset is needed before status.
-            if (reset_ids is not None) and (
-                len(reset_ids) > 0
-            ):
-                self.debug(
+            # If reset dpids set - then assume reset is needed before status.
+            if (reset_ids is not None) and (len(reset_ids) > 0):
+                _LOGGER.debug(
                     "Resetting command for DP IDs: %s",
                     reset_ids,
                 )
-                #Assume we want to request status updated for the same set of DP_IDs as the reset ones.
+                # Assume we want to request status updated for the same set of DP_IDs as the reset ones.
                 interface.set_updatedps_list(reset_ids)
 
-                #Reset the interface
+                # Reset the interface
                 await interface.reset(reset_ids)
 
-            #Detect any other non-manual DPS strings
+            # Detect any other non-manual DPS strings
             detected_dps = await interface.detect_available_dps()
         except Exception:  # pylint: disable=broad-except
             _LOGGER.debug("No DPS able to be detected")

--- a/custom_components/localtuya/config_flow.py
+++ b/custom_components/localtuya/config_flow.py
@@ -255,18 +255,25 @@ async def validate_input(hass: core.HomeAssistant, data):
                 reset_ids,
             )
         try:
-            detected_dps = await interface.detect_available_dps()
-        except Exception as ex:
-            try:
-                _LOGGER.debug(
-                    "Initial state update failed (%s), trying reset command", ex
+            #If reset dpids set - then assume reset is needed before status.
+            if (reset_ids is not None) and (
+                len(reset_ids) > 0
+            ):
+                self.debug(
+                    "Resetting command for DP IDs: %s",
+                    reset_ids,
                 )
-                if len(reset_ids) > 0:
-                    await interface.reset(reset_ids)
-                    detected_dps = await interface.detect_available_dps()
-            except Exception as ex:
-                _LOGGER.debug("No DPS able to be detected: %s", ex)
-                detected_dps = {}
+                #Assume we want to request status updated for the same set of DP_IDs as the reset ones.
+                interface.set_updatedps_list(reset_ids)
+
+                #Reset the interface
+                await interface.reset(reset_ids)
+
+            #Detect any other non-manual DPS strings
+            detected_dps = await interface.detect_available_dps()
+        except Exception:  # pylint: disable=broad-except
+            _LOGGER.debug("No DPS able to be detected")
+            detected_dps = {}
 
         # if manual DPs are set, merge these.
         _LOGGER.debug("Detected DPS: %s", detected_dps)

--- a/custom_components/localtuya/pytuya/__init__.py
+++ b/custom_components/localtuya/pytuya/__init__.py
@@ -508,8 +508,11 @@ class MessageDispatcher(ContextualLogger):
             if self.RESET_SEQNO in self.listeners:
                 self.debug("Got reset status update")
                 sem = self.listeners[self.RESET_SEQNO]
-                self.listeners[self.RESET_SEQNO] = msg
-                sem.release()
+                if isinstance(sem, asyncio.Semaphore):
+                    self.listeners[self.RESET_SEQNO] = msg
+                    sem.release()
+                else:
+                    self.debug("Got additional reset message without request - skipping: %s", sem)
             else:
                 self.debug("Got status update")
                 self.listener(msg)
@@ -590,6 +593,7 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
         self.dps_cache = {}
         self.local_nonce = b"0123456789abcdef"  # not-so-random random key
         self.remote_nonce = b""
+        self.dps_whitelist = UPDATE_DPS_WHITELIST
 
     def set_version(self, protocol_version):
         """Set the device version and eventually start available DPs detection."""
@@ -809,6 +813,9 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
             return await self.exchange(UPDATEDPS, dpIds)
 
         return True
+    def set_updatedps_list(self, update_list):
+        """Set the DPS to be requested with the update command"""
+        self.dps_whitelist = update_list
 
     async def update_dps(self, dps=None):
         """
@@ -824,7 +831,7 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
                 if self.dps_cache:
                     dps = [int(dp) for dp in self.dps_cache]
                     # filter non whitelisted dps
-                    dps = list(set(dps).intersection(set(UPDATE_DPS_WHITELIST)))
+                    dps = list(set(dps).intersection(set(self.dps_whitelist)))
             self.debug("updatedps() entry (dps %s, dps_cache %s)", dps, self.dps_cache)
             payload = self._generate_payload(UPDATEDPS, dps)
             enc_payload = self._encode_message(payload)

--- a/custom_components/localtuya/pytuya/__init__.py
+++ b/custom_components/localtuya/pytuya/__init__.py
@@ -496,8 +496,11 @@ class MessageDispatcher(ContextualLogger):
             self.debug("Got normal updatedps response")
             if self.RESET_SEQNO in self.listeners:
                 sem = self.listeners[self.RESET_SEQNO]
-                self.listeners[self.RESET_SEQNO] = msg
-                sem.release()
+                if isinstance(sem, asyncio.Semaphore):
+                    self.listeners[self.RESET_SEQNO] = msg
+                    sem.release()
+                else:
+                    self.debug("Got additional updatedps message without request - skipping: %s", sem)
         elif msg.cmd == SESS_KEY_NEG_RESP:
             self.debug("Got key negotiation response")
             if self.SESS_KEY_SEQNO in self.listeners:
@@ -508,6 +511,12 @@ class MessageDispatcher(ContextualLogger):
             if self.RESET_SEQNO in self.listeners:
                 self.debug("Got reset status update")
                 sem = self.listeners[self.RESET_SEQNO]
+                if isinstance(sem, asyncio.Semaphore):
+                    self.listeners[self.RESET_SEQNO] = msg
+                    sem.release()
+                else:
+                    self.debug("Got additional reset message without request - skipping: %s", sem)
+            else:
                 if isinstance(sem, asyncio.Semaphore):
                     self.listeners[self.RESET_SEQNO] = msg
                     sem.release()

--- a/custom_components/localtuya/pytuya/__init__.py
+++ b/custom_components/localtuya/pytuya/__init__.py
@@ -500,7 +500,10 @@ class MessageDispatcher(ContextualLogger):
                     self.listeners[self.RESET_SEQNO] = msg
                     sem.release()
                 else:
-                    self.debug("Got additional updatedps message without request - skipping: %s", sem)
+                    self.debug(
+                        "Got additional updatedps message without request - skipping: %s",
+                        sem,
+                    )
         elif msg.cmd == SESS_KEY_NEG_RESP:
             self.debug("Got key negotiation response")
             if self.SESS_KEY_SEQNO in self.listeners:
@@ -515,7 +518,10 @@ class MessageDispatcher(ContextualLogger):
                     self.listeners[self.RESET_SEQNO] = msg
                     sem.release()
                 else:
-                    self.debug("Got additional reset message without request - skipping: %s", sem)
+                    self.debug(
+                        "Got additional reset message without request - skipping: %s",
+                        sem,
+                    )
             else:
                 self.debug("Got status update")
                 self.listener(msg)

--- a/custom_components/localtuya/pytuya/__init__.py
+++ b/custom_components/localtuya/pytuya/__init__.py
@@ -517,12 +517,6 @@ class MessageDispatcher(ContextualLogger):
                 else:
                     self.debug("Got additional reset message without request - skipping: %s", sem)
             else:
-                if isinstance(sem, asyncio.Semaphore):
-                    self.listeners[self.RESET_SEQNO] = msg
-                    sem.release()
-                else:
-                    self.debug("Got additional reset message without request - skipping: %s", sem)
-            else:
                 self.debug("Got status update")
                 self.listener(msg)
         else:

--- a/custom_components/localtuya/pytuya/__init__.py
+++ b/custom_components/localtuya/pytuya/__init__.py
@@ -816,8 +816,9 @@ class TuyaProtocol(asyncio.Protocol, ContextualLogger):
             return await self.exchange(UPDATEDPS, dpIds)
 
         return True
+
     def set_updatedps_list(self, update_list):
-        """Set the DPS to be requested with the update command"""
+        """Set the DPS to be requested with the update command."""
         self.dps_whitelist = update_list
 
     async def update_dps(self, dps=None):


### PR DESCRIPTION
https://github.com/rospogrigio/localtuya/pull/1273 but with history a tiny bit cleaner.

> For devices configured with IDs to be sent with a RESET command, fix the logic. When i made the RESET logic less aggressive, I made the code only send it if no DPIDs were detected. However some devices (like power plugs), will present a DPID of 1 (the main switch), but not the additional power sensor DPIDs. The previous logic would never then trigger a RESET which would expose those additional DPIDs. This logic fixes that issue.

> @rospogrigio - as discussed in PR https://github.com/rospogrigio/localtuya/pull/1087. This code stands separate from that one. I've tested this week and all appears to be functioning correctly on my system.

@sibowler - I think your branch just wants 1x more git pull from upstream.

Recommend squash merging to clean things up a bit further