### PR TITLE
Add support for cover switch with independet stop datapoint

### DIFF
--- a/custom_components/localtuya/const.py
+++ b/custom_components/localtuya/const.py
@@ -64,6 +64,7 @@ CONF_VOLTAGE = "voltage"
 
 # cover
 CONF_COMMANDS_SET = "commands_set"
+CONF_STOP_DP = "stop_dp"
 CONF_POSITIONING_MODE = "positioning_mode"
 CONF_CURRENT_POSITION_DP = "current_position_dp"
 CONF_SET_POSITION_DP = "set_position_dp"

--- a/custom_components/localtuya/cover.py
+++ b/custom_components/localtuya/cover.py
@@ -18,6 +18,7 @@ from homeassistant.components.cover import (
 from .common import LocalTuyaEntity, async_setup_entry
 from .const import (
     CONF_COMMANDS_SET,
+    CONF_STOP_DP,
     CONF_CURRENT_POSITION_DP,
     CONF_POSITION_INVERTED,
     CONF_POSITIONING_MODE,
@@ -31,6 +32,7 @@ COVER_ONOFF_CMDS = "on_off_stop"
 COVER_OPENCLOSE_CMDS = "open_close_stop"
 COVER_FZZZ_CMDS = "fz_zz_stop"
 COVER_12_CMDS = "1_2_3"
+COVER_CONTINUE_CMDS = "open_close_continue"
 COVER_MODE_NONE = "none"
 COVER_MODE_POSITION = "position"
 COVER_MODE_TIMED = "timed"
@@ -45,8 +47,9 @@ def flow_schema(dps):
     """Return schema used in config flow."""
     return {
         vol.Optional(CONF_COMMANDS_SET): vol.In(
-            [COVER_ONOFF_CMDS, COVER_OPENCLOSE_CMDS, COVER_FZZZ_CMDS, COVER_12_CMDS]
+            [COVER_ONOFF_CMDS, COVER_OPENCLOSE_CMDS, COVER_FZZZ_CMDS, COVER_12_CMDS, COVER_CONTINUE_CMDS]
         ),
+        vol.Optional(CONF_STOP_DP): vol.In(dps),
         vol.Optional(CONF_POSITIONING_MODE, default=DEFAULT_POSITIONING_MODE): vol.In(
             [COVER_MODE_NONE, COVER_MODE_POSITION, COVER_MODE_TIMED]
         ),
@@ -178,7 +181,13 @@ class LocaltuyaCover(LocalTuyaEntity, CoverEntity):
     async def async_stop_cover(self, **kwargs):
         """Stop the cover."""
         self.debug("Launching command %s to cover ", self._stop_cmd)
-        await self._device.set_dp(self._stop_cmd, self._dp_id)
+        commands_set = DEFAULT_COMMANDS_SET
+        if self.has_config(CONF_COMMANDS_SET):
+            commands_set = self._config[CONF_COMMANDS_SET]
+        if commands_set == COVER_CONTINUE_CMDS and self.has_config(CONF_STOP_DP):
+            await self._device.set_dp(True, self._config[CONF_STOP_DP])
+        else:
+            await self._device.set_dp(self._stop_cmd, self._dp_id)
 
     def status_restored(self, stored_state):
         """Restore the last stored cover status."""

--- a/custom_components/localtuya/strings.json
+++ b/custom_components/localtuya/strings.json
@@ -58,6 +58,7 @@
                     "current_consumption": "Current Consumption",
                     "voltage": "Voltage",
                     "commands_set": "Open_Close_Stop Commands Set",
+                    "stop_dp": "Stop switch (for *open_close_continue* command set only)",
                     "positioning_mode": "Positioning mode",
                     "current_position_dp": "Current Position (for *position* mode only)",
                     "set_position_dp": "Set Position (for *position* mode only)",

--- a/custom_components/localtuya/translations/en.json
+++ b/custom_components/localtuya/translations/en.json
@@ -121,6 +121,7 @@
                     "current_consumption": "Current Consumption",
                     "voltage": "Voltage",
                     "commands_set": "Open_Close_Stop Commands Set",
+                    "stop_dp": "Stop switch (for *open_close_continue* command set only)",
                     "positioning_mode": "Positioning mode",
                     "current_position_dp": "Current Position (for *position* mode only)",
                     "set_position_dp": "Set Position (for *position* mode only)",

--- a/custom_components/localtuya/translations/it.json
+++ b/custom_components/localtuya/translations/it.json
@@ -119,6 +119,7 @@
                     "current_consumption": "Potenza",
                     "voltage": "Tensione",
                     "commands_set": "Set di comandi Aperto_Chiuso_Stop",
+                    "stop_dp": "Interruttore di stop (solo per modalità *open_close_continue*)",
                     "positioning_mode": "Modalità di posizionamento",
                     "current_position_dp": "Posizione attuale (solo per la modalità *posizione*)",
                     "set_position_dp": "Imposta posizione (solo per modalità *posizione*)",

--- a/custom_components/localtuya/translations/pt-BR.json
+++ b/custom_components/localtuya/translations/pt-BR.json
@@ -119,6 +119,7 @@
                     "current_consumption": "Consumo atual",
                     "voltage": "Voltagem",
                     "commands_set": "Conjunto de comandos Abrir_Fechar_Parar",
+                    "stop_dp": "Interruptor de stop (somente para o modo *open_close_continue*)",
                     "positioning_mode": "Modo de posicionamento",
                     "current_position_dp": "Posição atual (somente para o modo *posição*)",
                     "set_position_dp": "Definir posição (somente para o modo *posição*)",


### PR DESCRIPTION

I recently purchased a [Maxcio WF-CS01 **(Gen 6.1)**](https://www.amazon.es/dp/B0BQ2GMCKV) cover switch.
This new 6.1 generation has an "open_close_continue" command set:

- "open" makes the cover start to open
- "close" makes the cover start to close
- "continue" has no apparent effect

There is an independent datapoint (ID: 101) to stop the cover:

- `True` makes the cover stop moving.

Support for this new behaviour may be useful to others.
Regards