### PR TITLE
Fix addr: prefix

### DIFF
--- a/custom_components/localtuya/common.py
+++ b/custom_components/localtuya/common.py
@@ -184,6 +184,9 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
     async def _make_connection(self):
         """Subscribe localtuya entity events."""
         self.info("Trying to connect to %s...", self._dev_config_entry[CONF_HOST])
+        
+        if "addr:" in self._dev_config_entry[CONF_HOST]:
+            self._dev_config_entry[CONF_HOST] = self._dev_config_entry[CONF_HOST].replace("addr:","")
 
         try:
             self._interface = await pytuya.connect(


### PR DESCRIPTION
Tuya vaccum by Elvita returns "addr:" before the ip address. This makes HA try to connect to a non-existing dns address. Thus, resulting in an error. Adding this in case anyone else were to stumble on the same problem.

Pretty hacky fix, but it shouldn't disturb any other device functionality.