### PR TITLE
Update Cover.py and Fixes return current state.

### DIFF
--- a/custom_components/localtuya/cover.py
+++ b/custom_components/localtuya/cover.py
@@ -98,7 +98,7 @@ class LocaltuyaCover(LocalTuyaEntity, CoverEntity):
     def _current_state(self) -> str:
         """Return the current state of the cover."""
         state = self._current_state_action
-        curr_pos = self._current_cover_position
+        curr_pos = self.current_cover_position
         # Reset STATE when cover is fully closed or fully opened.
         if (state == STATE_CLOSING and curr_pos == 0) or (state == STATE_OPENING and curr_pos == 100):
             self._current_state_action = STATE_STOPPED

--- a/custom_components/localtuya/cover.py
+++ b/custom_components/localtuya/cover.py
@@ -105,10 +105,9 @@ class LocaltuyaCover(LocalTuyaEntity, CoverEntity):
         # in case cover moving by set position cmd.
         if (self._current_state_action == STATE_SET_CLOSING
             or self._current_state_action == STATE_SET_OPENING):
-            curr_pos = self.current_cover_position
             set_pos = self._set_new_position
             # Reset state whenn cover reached the position.
-            if curr_pos - set_pos < 5 and curr_pos - set_pos > -5 :
+            if curr_pos - set_pos < 5 and curr_pos - set_pos >= -5 :
                 self._current_state_action = STATE_STOPPED 
         return self._current_state_action
     
@@ -274,7 +273,7 @@ class LocaltuyaCover(LocalTuyaEntity, CoverEntity):
             pos_diff = position - curr_pos
             if pos_diff > 5:
                 self._current_state_action = STATE_SET_OPENING
-            elif pos_diff < -5:
+            elif pos_diff <= -5:
                 self._current_state_action = STATE_SET_CLOSING
         # Write state data.
         self.async_write_ha_state()


### PR DESCRIPTION
This PR Contains many fixes for using cover locally also updated supported features since the current one are deprecated as of Home Assistant 2022.5. hope u can check this out when you can. @rospogrigio since states is needed in automations.
summery, rather than depending on tuya states which might be broken depend on HA, quicker and works with every device.

- What was the issue?
1- covers doesn't return any states whither it's opening or closing. this's because states only update after the device move and updates. 

  2- when cover state is closed it won't return opening state, this's because cover current position update after motor finish the move. and `is_closed` depend only on current position value.

  3- Covers doesn't return opening or closing using set position command, this because many if not all Tuya covers don't have working sensor for opening/closing.

- What this PR fix?
1- Return immediately whither it's opening or closing.
  2- Return state using set position.
  3- Update supported features.
  4- States is kinda works for NONE position covers.
