### PR TITLE
Add categories for entities and selector

### DIFF
--- a/custom_components/localtuya/common.py
+++ b/custom_components/localtuya/common.py
@@ -15,6 +15,7 @@ from homeassistant.const import (
     CONF_PLATFORM,
     CONF_SCAN_INTERVAL,
     STATE_UNKNOWN,
+    EntityCategory,
 )
 from homeassistant.core import callback
 from homeassistant.helpers.dispatcher import (
@@ -39,6 +40,8 @@ from .const import (
     DATA_CLOUD,
     DOMAIN,
     TUYA_DEVICES,
+    CONF_CATEGORY_ENTITY,
+    DEFAULT_CATEGORIES,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -477,6 +480,30 @@ class LocalTuyaEntity(RestoreEntity, pytuya.ContextualLogger):
     def available(self):
         """Return if device is available or not."""
         return str(self._dp_id) in self._status
+
+    @property
+    def entity_category(self) -> str:
+        """Return the category of the entity."""
+        if self.has_config(CONF_CATEGORY_ENTITY):
+            category = self._config[CONF_CATEGORY_ENTITY]
+            if EntityCategory.CONFIG in category:
+                category = EntityCategory.CONFIG
+            elif EntityCategory.DIAGNOSTIC in category:
+                category = EntityCategory.DIAGNOSTIC
+            else:
+                category = None
+            return category
+        else:
+            # Set Default values for unconfigured devices.
+            if self.has_config(CONF_PLATFORM):
+                platform = self._config[CONF_PLATFORM]
+            if any(platform in i for i in DEFAULT_CATEGORIES["CONTROL"]):
+                return None
+            elif any(platform in i for i in DEFAULT_CATEGORIES["CONFIG"]):
+                return EntityCategory.CONFIG
+            elif any(platform in i for i in DEFAULT_CATEGORIES["DIAGNOSTIC"]):
+                return EntityCategory.DIAGNOSTIC
+        return None
 
     def dps(self, dp_index):
         """Return cached value for DPS index."""

--- a/custom_components/localtuya/const.py
+++ b/custom_components/localtuya/const.py
@@ -1,4 +1,5 @@
 """Constants for localtuya integration."""
+from homeassistant.const import EntityCategory
 
 DOMAIN = "localtuya"
 
@@ -47,6 +48,7 @@ CONF_MANUAL_DPS = "manual_dps_strings"
 CONF_DEFAULT_VALUE = "dps_default_value"
 CONF_RESET_DPIDS = "reset_dpids"
 CONF_PASSIVE_ENTITY = "is_passive_entity"
+CONF_CATEGORY_ENTITY = "device_category"
 
 # light
 CONF_BRIGHTNESS_LOWER = "brightness_lower"
@@ -134,3 +136,17 @@ CONF_OPTIONS_FRIENDLY = "select_options_friendly"
 # States
 ATTR_STATE = "raw_state"
 CONF_RESTORE_ON_RECONNECT = "restore_on_reconnect"
+
+# Categories
+ENTITY_CATEGORY = {
+    None:"Controls",
+    EntityCategory.CONFIG:"Configuration",
+    EntityCategory.DIAGNOSTIC:"Diagnostic"
+}
+
+# Default Categories
+DEFAULT_CATEGORIES = {
+    "CONTROL" : ['switch', 'climate','fan','vacuum','light'],
+    "CONFIG" : ['select','number'],
+    "DIAGNOSTIC" : ['sensor','binary_sensor']
+}

--- a/custom_components/localtuya/translations/en.json
+++ b/custom_components/localtuya/translations/en.json
@@ -193,7 +193,8 @@
                     "min_value": "Minimum Value",
                     "max_value": "Maximum Value",
                     "step_size": "Minimum increment between numbers",
-                    "is_passive_entity": "Passive entity - requires integration to send initialisation value"
+                    "is_passive_entity": "Passive entity - requires integration to send initialisation value",
+                    "device_category": "Show the entity in this categroy"
                 }
             }
         }


### PR DESCRIPTION
hello, this PR will add the possibility to configure the entitles categories in HA it's won't break the old setup at all matter fact it will automatic handle old entitles and organize them into default categories *usually 
also this come with ` HA new helper SELECTOR which will require HA 2022.4 at least using this method will help alot to develops config flow since it's also add the possibility  to use 'dict' and changes labels instead showing values as labels also added function to handle selectors method.
in config flow & unconfigured entitles will auto selected the default values in const

Config Flow option.
![Localtuya_cat_options](https://github.com/rospogrigio/localtuya/assets/46300268/0db80326-13b7-44e6-b856-100b510c5fd6)

POV:
![image](https://github.com/rospogrigio/localtuya/assets/46300268/d297d056-bdca-4814-be58-8c88e4b82608)
