### PR TITLE
Fixes #1328

### DIFF
--- a/custom_components/localtuya/__init__.py
+++ b/custom_components/localtuya/__init__.py
@@ -255,8 +255,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         res = await tuya_api.async_get_access_token()
         if res != "ok":
             _LOGGER.error("Cloud API connection failed: %s", res)
-        _LOGGER.info("Cloud API connection succeeded.")
-        res = await tuya_api.async_get_devices_list()
+        else:
+            _LOGGER.info("Cloud API connection succeeded.")
+            res = await tuya_api.async_get_devices_list()
     hass.data[DOMAIN][DATA_CLOUD] = tuya_api
 
     async def setup_entities(device_ids):

--- a/custom_components/localtuya/cloud_api.py
+++ b/custom_components/localtuya/cloud_api.py
@@ -101,7 +101,10 @@ class TuyaCloudApi:
 
     async def async_get_access_token(self):
         """Obtain a valid access token."""
-        resp = await self.async_make_request("GET", "/v1.0/token?grant_type=1")
+        try:
+            resp = await self.async_make_request("GET", "/v1.0/token?grant_type=1")
+        except requests.exceptions.ConnectionError:
+            return "Request failed, status ConnectionError"
 
         if not resp.ok:
             return "Request failed, status " + str(resp.status)


### PR DESCRIPTION
Original Issue: https://github.com/rospogrigio/localtuya/issues/1328   
    
Restarting HomeAssistant without an external internet connection fails initialization when API is set in config. Tries to get access token and has an uncontrolled crash.    
    
**Note:** The `else` in `__init.py` is because `tuya_api.async_get_devices_list()` **also** causes a crash without an internet connection.
    
This also fixes if there's a non-**ok** response from the cloud. This might not be beneficial in all cases; Example: having invalid credentials, it might be better to have the crash so the user is aware of the issue. If that is desired I propose having a custom exception instead of waiting until `async_get_devices_list` fails.
