### PR TITLE
fix bug when climate entity is using default min/max temp and temp un…

### DIFF
--- a/custom_components/localtuya/climate.py
+++ b/custom_components/localtuya/climate.py
@@ -343,14 +343,22 @@ class LocaltuyaClimate(LocalTuyaEntity, ClimateEntity):
         """Return the minimum temperature."""
         if self.has_config(CONF_MIN_TEMP_DP):
             return self.dps_conf(CONF_MIN_TEMP_DP)
-        return DEFAULT_MIN_TEMP
+        # DEFAULT_MIN_TEMP is in C
+        if self.temperature_unit == TEMP_FAHRENHEIT:
+            return DEFAULT_MIN_TEMP * 1.8 + 32
+        else:
+            return DEFAULT_MIN_TEMP
 
     @property
     def max_temp(self):
         """Return the maximum temperature."""
         if self.has_config(CONF_MAX_TEMP_DP):
             return self.dps_conf(CONF_MAX_TEMP_DP)
-        return DEFAULT_MAX_TEMP
+        # DEFAULT_MAX_TEMP is in C
+        if self.temperature_unit == TEMP_FAHRENHEIT:
+            return DEFAULT_MAX_TEMP * 1.8 + 32
+        else:
+            return DEFAULT_MAX_TEMP
 
     def status_updated(self):
         """Device status was updated."""


### PR DESCRIPTION
The default min/max temp constants are in C but when the climate entity is set up with F this will cause incorrect boundary check and an inability to change the temperature from the home assistant entity UI widget.