### PR TITLE
Introducing support for Zigbee devices

### DIFF
--- a/custom_components/localtuya/common.py
+++ b/custom_components/localtuya/common.py
@@ -190,7 +190,7 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
                 self._dev_config_entry[CONF_HOST],
                 self._dev_config_entry[CONF_DEVICE_ID],
                 self._local_key,
-                float(self._dev_config_entry[CONF_PROTOCOL_VERSION]),
+                self._dev_config_entry[CONF_PROTOCOL_VERSION],
                 self._dev_config_entry.get(CONF_ENABLE_DEBUG, False),
                 self,
             )

--- a/custom_components/localtuya/const.py
+++ b/custom_components/localtuya/const.py
@@ -27,7 +27,10 @@ ATTR_VOLTAGE = "voltage"
 ATTR_UPDATED_AT = "updated_at"
 
 # config flow
+CONF_GW_ID = "gw_id"
 CONF_LOCAL_KEY = "local_key"
+CONF_NODEID = "node_id"
+CONF_SUB = "sub"
 CONF_ENABLE_DEBUG = "enable_debug"
 CONF_PROTOCOL_VERSION = "protocol_version"
 CONF_DPS_STRINGS = "dps_strings"


### PR DESCRIPTION
Introducing support for Zigbee devices.
Devices are automatically detected if the Cloud APIs are used.
These devices must be configured setting the dedicated "sub_device" protocol.