### PR TITLE
Logging excessive warnings on disconnect

### DIFF
--- a/custom_components/localtuya/common.py
+++ b/custom_components/localtuya/common.py
@@ -148,6 +148,7 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
         self._entities = []
         self._local_key = self._dev_config_entry[CONF_LOCAL_KEY]
         self._default_reset_dpids = None
+        self._disconnect_warning_logged = False
         if CONF_RESET_DPIDS in self._dev_config_entry:
             reset_ids_str = self._dev_config_entry[CONF_RESET_DPIDS].split(",")
 
@@ -195,10 +196,18 @@ class TuyaDevice(pytuya.TuyaListener, pytuya.ContextualLogger):
                 self,
             )
             self._interface.add_dps_to_request(self.dps_to_request)
+            self._disconnect_warning_logged = False
         except Exception as ex:  # pylint: disable=broad-except
-            self.warning(
-                f"Failed to connect to {self._dev_config_entry[CONF_HOST]}: %s", ex
-            )
+            if not self._disconnect_warning_logged:
+                self.warning(
+                    f"Failed to connect to {self._dev_config_entry[CONF_HOST]}: %s", ex
+                )
+                self._disconnect_warning_logged = True
+            else:
+                self.info(
+                    f"Failed to connect to {self._dev_config_entry[CONF_HOST]}: %s", ex
+                )
+
             if self._interface is not None:
                 await self._interface.close()
                 self._interface = None


### PR DESCRIPTION
When a tuya device is turned off the integration attempts to reconnect periodically and logs warnings when each reconnect attempt fails.  This behavior may fill up the log with excessive warnings if the device is off for a long period of time.  With this change a warning is logged when the first reconnect fails and on subsequent attempts an info level message is logged.

This update allows the integration to meet this specific silver quality requirement:

https://developers.home-assistant.io/docs/integration_quality_scale_index/#silver-
"Handles device/service unavailable. Log a warning once when unavailable, log once when reconnected."

My specific use case.  I have a Sunbeam mattress pad. When I leave the house for an extended period of time I unplug the mattress pad.  When I do this my log fills up with warnings.

New behavior:

```
2023-10-30 12:27:46.561 INFO (MainThread) [homeassistant.components.select] Setting up select.localtuya
2023-10-30 12:27:46.587 INFO (MainThread) [custom_components.localtuya.common] [eb1...o2d] Trying to connect to 192.168.20.102...
2023-10-30 12:27:46.617 INFO (MainThread) [custom_components.localtuya.common] [eb1...o2d] Successfully connected to 192.168.20.102
2023-10-30 12:30:49.867 WARNING (MainThread) [custom_components.localtuya.common] [eb1...o2d] Disconnected - waiting for discovery broadcast
2023-10-30 12:31:40.185 INFO (MainThread) [custom_components.localtuya.common] [eb1...o2d] Trying to connect to 192.168.20.102...
2023-10-30 12:33:47.408 WARNING (MainThread) [custom_components.localtuya.common] [eb1...o2d] Failed to connect to 192.168.20.102: [Errno 110] Connect call failed ('192.168.20.102', 6668)
2023-10-30 12:34:40.188 INFO (MainThread) [custom_components.localtuya.common] [eb1...o2d] Trying to connect to 192.168.20.102...
2023-10-30 12:36:47.504 INFO (MainThread) [custom_components.localtuya.common] [eb1...o2d] Failed to connect to 192.168.20.102: [Errno 110] Connect call failed ('192.168.20.102', 6668)
2023-10-30 12:37:40.192 INFO (MainThread) [custom_components.localtuya.common] [eb1...o2d] Trying to connect to 192.168.20.102...
2023-10-30 12:39:47.472 INFO (MainThread) [custom_components.localtuya.common] [eb1...o2d] Failed to connect to 192.168.20.102: [Errno 110] Connect call failed ('192.168.20.102', 6668)
2023-10-30 12:40:40.196 INFO (MainThread) [custom_components.localtuya.common] [eb1...o2d] Trying to connect to 192.168.20.102...
2023-10-30 12:42:47.440 INFO (MainThread) [custom_components.localtuya.common] [eb1...o2d] Failed to connect to 192.168.20.102: [Errno 110] Connect call failed ('192.168.20.102', 6668)
2023-10-30 12:27:46.561 INFO (MainThread) [homeassistant.components.select] Setting up select.localtuya
2023-10-30 12:27:46.587 INFO (MainThread) [custom_components.localtuya.common] [eb1...o2d] Trying to connect to 192.168.20.102...
2023-10-30 12:27:46.617 INFO (MainThread) [custom_components.localtuya.common] [eb1...o2d] Successfully connected to 192.168.20.102
2023-10-30 12:30:49.867 WARNING (MainThread) [custom_components.localtuya.common] [eb1...o2d] Disconnected - waiting for discovery broadcast
2023-10-30 12:31:40.185 INFO (MainThread) [custom_components.localtuya.common] [eb1...o2d] Trying to connect to 192.168.20.102...
2023-10-30 12:33:47.408 WARNING (MainThread) [custom_components.localtuya.common] [eb1...o2d] Failed to connect to 192.168.20.102: [Errno 110] Connect call failed ('192.168.20.102', 6668)
2023-10-30 12:34:40.188 INFO (MainThread) [custom_components.localtuya.common] [eb1...o2d] Trying to connect to 192.168.20.102...
2023-10-30 12:36:47.504 INFO (MainThread) [custom_components.localtuya.common] [eb1...o2d] Failed to connect to 192.168.20.102: [Errno 110] Connect call failed ('192.168.20.102', 6668)
2023-10-30 12:37:40.192 INFO (MainThread) [custom_components.localtuya.common] [eb1...o2d] Trying to connect to 192.168.20.102...
2023-10-30 12:39:47.472 INFO (MainThread) [custom_components.localtuya.common] [eb1...o2d] Failed to connect to 192.168.20.102: [Errno 110] Connect call failed ('192.168.20.102', 6668)
2023-10-30 12:40:40.196 INFO (MainThread) [custom_components.localtuya.common] [eb1...o2d] Trying to connect to 192.168.20.102...
2023-10-30 12:42:47.440 INFO (MainThread) [custom_components.localtuya.common] [eb1...o2d] Failed to connect to 192.168.20.102: [Errno 110] Connect call failed ('192.168.20.102', 6668)
2023-10-30 12:43:40.198 INFO (MainThread) [custom_components.localtuya.common] [eb1...o2d] Trying to connect to 192.168.20.102...
2023-10-30 12:44:43.359 INFO (MainThread) [custom_components.localtuya.common] [eb1...o2d] Successfully connected to 192.168.20.102

```
