### PR TITLE
Fix is_closed method which always return false

### DIFF
--- a/custom_components/localtuya/cover.py
+++ b/custom_components/localtuya/cover.py
@@ -108,13 +108,13 @@ class LocaltuyaCover(LocalTuyaEntity, CoverEntity):
     def is_closed(self):
         """Return if the cover is closed or not."""
         if self._config[CONF_POSITIONING_MODE] == COVER_MODE_NONE:
-            return False
+            return None
 
         if self._current_cover_position == 0:
             return True
         if self._current_cover_position == 100:
             return False
-        return False
+        return None
 
     async def async_set_cover_position(self, **kwargs):
         """Move the cover to a specific position."""


### PR DESCRIPTION
The method is_closed() should return None when the cover didn't support the positioning control

Issue: N/A