### PR TITLE
Fix #1610 - Replaced SUPPORT_* with enums

### DIFF
--- a/custom_components/localtuya/climate.py
+++ b/custom_components/localtuya/climate.py
@@ -20,9 +20,7 @@ from homeassistant.components.climate.const import (
     PRESET_ECO,
     PRESET_HOME,
     PRESET_NONE,
-    SUPPORT_PRESET_MODE,
-    SUPPORT_TARGET_TEMPERATURE,
-    SUPPORT_TARGET_TEMPERATURE_RANGE,
+    ClimateEntityFeature,
 )
 from homeassistant.const import (
     ATTR_TEMPERATURE,
@@ -30,8 +28,7 @@ from homeassistant.const import (
     PRECISION_HALVES,
     PRECISION_TENTHS,
     PRECISION_WHOLE,
-    TEMP_CELSIUS,
-    TEMP_FAHRENHEIT,
+    UnitOfTemperature,
 )
 
 from .common import LocalTuyaEntity, async_setup_entry
@@ -191,11 +188,11 @@ class LocaltuyaClimate(LocalTuyaEntity, ClimateEntity):
         """Flag supported features."""
         supported_features = 0
         if self.has_config(CONF_TARGET_TEMPERATURE_DP):
-            supported_features = supported_features | SUPPORT_TARGET_TEMPERATURE
+            supported_features = supported_features | ClimateEntityFeature.TARGET_TEMPERATURE
         if self.has_config(CONF_MAX_TEMP_DP):
-            supported_features = supported_features | SUPPORT_TARGET_TEMPERATURE_RANGE
+            supported_features = supported_features | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
         if self.has_config(CONF_PRESET_DP) or self.has_config(CONF_ECO_DP):
-            supported_features = supported_features | SUPPORT_PRESET_MODE
+            supported_features = supported_features | ClimateEntityFeature.PRESET_MODE
         return supported_features
 
     @property
@@ -215,8 +212,8 @@ class LocaltuyaClimate(LocalTuyaEntity, ClimateEntity):
             self._config.get(CONF_TEMPERATURE_UNIT, DEFAULT_TEMPERATURE_UNIT)
             == TEMPERATURE_FAHRENHEIT
         ):
-            return TEMP_FAHRENHEIT
-        return TEMP_CELSIUS
+            return UnitOfTemperature.FAHRENHEIT
+        return UnitOfTemperature.CELSIUS
 
     @property
     def hvac_mode(self):
@@ -344,7 +341,7 @@ class LocaltuyaClimate(LocalTuyaEntity, ClimateEntity):
         if self.has_config(CONF_MIN_TEMP_DP):
             return self.dps_conf(CONF_MIN_TEMP_DP)
         # DEFAULT_MIN_TEMP is in C
-        if self.temperature_unit == TEMP_FAHRENHEIT:
+        if self.temperature_unit == UnitOfTemperature.FAHRENHEIT:
             return DEFAULT_MIN_TEMP * 1.8 + 32
         else:
             return DEFAULT_MIN_TEMP
@@ -355,7 +352,7 @@ class LocaltuyaClimate(LocalTuyaEntity, ClimateEntity):
         if self.has_config(CONF_MAX_TEMP_DP):
             return self.dps_conf(CONF_MAX_TEMP_DP)
         # DEFAULT_MAX_TEMP is in C
-        if self.temperature_unit == TEMP_FAHRENHEIT:
+        if self.temperature_unit == UnitOfTemperature.FAHRENHEIT:
             return DEFAULT_MAX_TEMP * 1.8 + 32
         else:
             return DEFAULT_MAX_TEMP

--- a/custom_components/localtuya/cover.py
+++ b/custom_components/localtuya/cover.py
@@ -8,11 +8,7 @@ import voluptuous as vol
 from homeassistant.components.cover import (
     ATTR_POSITION,
     DOMAIN,
-    SUPPORT_CLOSE,
-    SUPPORT_OPEN,
-    SUPPORT_SET_POSITION,
-    SUPPORT_STOP,
-    CoverEntity,
+    CoverEntity, CoverEntityFeature,
 )
 
 from .common import LocalTuyaEntity, async_setup_entry
@@ -80,9 +76,9 @@ class LocaltuyaCover(LocalTuyaEntity, CoverEntity):
     @property
     def supported_features(self):
         """Flag supported features."""
-        supported_features = SUPPORT_OPEN | SUPPORT_CLOSE | SUPPORT_STOP
+        supported_features = CoverEntityFeature.OPEN | CoverEntityFeature.CLOSE | CoverEntityFeature.STOP
         if self._config[CONF_POSITIONING_MODE] != COVER_MODE_NONE:
-            supported_features = supported_features | SUPPORT_SET_POSITION
+            supported_features = supported_features | CoverEntityFeature.SET_POSITION
         return supported_features
 
     @property

--- a/custom_components/localtuya/fan.py
+++ b/custom_components/localtuya/fan.py
@@ -9,10 +9,7 @@ from homeassistant.components.fan import (
     DIRECTION_FORWARD,
     DIRECTION_REVERSE,
     DOMAIN,
-    SUPPORT_DIRECTION,
-    SUPPORT_OSCILLATE,
-    SUPPORT_SET_SPEED,
-    FanEntity,
+    FanEntity, FanEntityFeature,
 )
 from homeassistant.util.percentage import (
     int_states_in_range,
@@ -194,13 +191,13 @@ class LocaltuyaFan(LocalTuyaEntity, FanEntity):
         features = 0
 
         if self.has_config(CONF_FAN_OSCILLATING_CONTROL):
-            features |= SUPPORT_OSCILLATE
+            features |= FanEntityFeature.OSCILLATE
 
         if self.has_config(CONF_FAN_SPEED_CONTROL):
-            features |= SUPPORT_SET_SPEED
+            features |= FanEntityFeature.SET_SPEED
 
         if self.has_config(CONF_FAN_DIRECTION):
-            features |= SUPPORT_DIRECTION
+            features |= FanEntityFeature.DIRECTION
 
         return features
 

--- a/custom_components/localtuya/vacuum.py
+++ b/custom_components/localtuya/vacuum.py
@@ -11,16 +11,7 @@ from homeassistant.components.vacuum import (
     STATE_IDLE,
     STATE_PAUSED,
     STATE_RETURNING,
-    SUPPORT_BATTERY,
-    SUPPORT_FAN_SPEED,
-    SUPPORT_LOCATE,
-    SUPPORT_PAUSE,
-    SUPPORT_RETURN_HOME,
-    SUPPORT_START,
-    SUPPORT_STATE,
-    SUPPORT_STATUS,
-    SUPPORT_STOP,
-    StateVacuumEntity,
+    StateVacuumEntity, VacuumEntityFeature,
 )
 
 from .common import LocalTuyaEntity, async_setup_entry
@@ -123,21 +114,21 @@ class LocaltuyaVacuum(LocalTuyaEntity, StateVacuumEntity):
     def supported_features(self):
         """Flag supported features."""
         supported_features = (
-            SUPPORT_START
-            | SUPPORT_PAUSE
-            | SUPPORT_STOP
-            | SUPPORT_STATUS
-            | SUPPORT_STATE
+            VacuumEntityFeature.START
+            | VacuumEntityFeature.PAUSE
+            | VacuumEntityFeature.STOP
+            | VacuumEntityFeature.STATUS
+            | VacuumEntityFeature.STATE
         )
 
         if self.has_config(CONF_RETURN_MODE):
-            supported_features = supported_features | SUPPORT_RETURN_HOME
+            supported_features = supported_features | VacuumEntityFeature.RETURN_HOME
         if self.has_config(CONF_FAN_SPEED_DP):
-            supported_features = supported_features | SUPPORT_FAN_SPEED
+            supported_features = supported_features | VacuumEntityFeature.FAN_SPEED
         if self.has_config(CONF_BATTERY_DP):
-            supported_features = supported_features | SUPPORT_BATTERY
+            supported_features = supported_features | VacuumEntityFeature.BATTERY
         if self.has_config(CONF_LOCATE_DP):
-            supported_features = supported_features | SUPPORT_LOCATE
+            supported_features = supported_features | VacuumEntityFeature.LOCATE
 
         return supported_features
 

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 {
   "name": "Local Tuya",
-  "homeassistant": "0.116.0"
+  "homeassistant": "2024.1.0"
 }


### PR DESCRIPTION
Replaced SUPPORT_* with enums, set minimum HA version in HACS configuration to 2024.1.0

Issue #1610 

- Replaced SUPPORT_* with enums
- Set minimum HA version in HACS configuration to 2024.1.0