### PR TITLE
Fix brightness when COLOR is not configured and white mode not exists

### DIFF
--- a/custom_components/localtuya/light.py
+++ b/custom_components/localtuya/light.py
@@ -323,7 +323,7 @@ class LocaltuyaLight(LocalTuyaEntity, LightEntity):
                 self._lower_brightness,
                 self._upper_brightness,
             )
-            if self.is_white_mode:
+            if self.is_white_mode or self.dps_conf(CONF_COLOR) is None:
                 states[self._config.get(CONF_BRIGHTNESS)] = brightness
             else:
                 if self.__is_color_rgb_encoded():


### PR DESCRIPTION
This handles the case where your color modes doesn't include white. In my case it is:
- normal
- sleep
- nature

With this implementation setting up brightness is possible.