### PR TITLE
AC Fix for extended modes

### DIFF
--- a/custom_components/localtuya/climate.py
+++ b/custom_components/localtuya/climate.py
@@ -15,12 +15,17 @@ from homeassistant.components.climate.const import (
     CURRENT_HVAC_IDLE,
     HVAC_MODE_AUTO,
     HVAC_MODE_HEAT,
+    HVAC_MODE_COOL,
+    HVAC_MODE_DRY, 
+    HVAC_MODE_FAN_ONLY,
     HVAC_MODE_OFF,
     PRESET_AWAY,
     PRESET_ECO,
     PRESET_HOME,
     PRESET_NONE,
-    ClimateEntityFeature,
+    SUPPORT_PRESET_MODE,
+    SUPPORT_TARGET_TEMPERATURE,
+    SUPPORT_TARGET_TEMPERATURE_RANGE,
 )
 from homeassistant.const import (
     ATTR_TEMPERATURE,
@@ -28,7 +33,8 @@ from homeassistant.const import (
     PRECISION_HALVES,
     PRECISION_TENTHS,
     PRECISION_WHOLE,
-    UnitOfTemperature,
+    TEMP_CELSIUS,
+    TEMP_FAHRENHEIT,
 )
 
 from .common import LocalTuyaEntity, async_setup_entry
@@ -76,6 +82,13 @@ HVAC_MODE_SETS = {
     "1/0": {
         HVAC_MODE_HEAT: "1",
         HVAC_MODE_AUTO: "0",
+    }, 
+    "COOL/HEAT/DRY/FAN": { 
+        HVAC_MODE_HEAT: "Heat", 
+        HVAC_MODE_COOL: "Cool", 
+        HVAC_MODE_DRY: "Dyr", 
+        HVAC_MODE_FAN_ONLY: "Fan", 
+        
     },
 }
 HVAC_ACTION_SETS = {
@@ -188,11 +201,11 @@ class LocaltuyaClimate(LocalTuyaEntity, ClimateEntity):
         """Flag supported features."""
         supported_features = 0
         if self.has_config(CONF_TARGET_TEMPERATURE_DP):
-            supported_features = supported_features | ClimateEntityFeature.TARGET_TEMPERATURE
+            supported_features = supported_features | SUPPORT_TARGET_TEMPERATURE
         if self.has_config(CONF_MAX_TEMP_DP):
-            supported_features = supported_features | ClimateEntityFeature.TARGET_TEMPERATURE_RANGE
+            supported_features = supported_features | SUPPORT_TARGET_TEMPERATURE_RANGE
         if self.has_config(CONF_PRESET_DP) or self.has_config(CONF_ECO_DP):
-            supported_features = supported_features | ClimateEntityFeature.PRESET_MODE
+            supported_features = supported_features | SUPPORT_PRESET_MODE
         return supported_features
 
     @property
@@ -212,8 +225,8 @@ class LocaltuyaClimate(LocalTuyaEntity, ClimateEntity):
             self._config.get(CONF_TEMPERATURE_UNIT, DEFAULT_TEMPERATURE_UNIT)
             == TEMPERATURE_FAHRENHEIT
         ):
-            return UnitOfTemperature.FAHRENHEIT
-        return UnitOfTemperature.CELSIUS
+            return TEMP_FAHRENHEIT
+        return TEMP_CELSIUS
 
     @property
     def hvac_mode(self):
@@ -340,22 +353,14 @@ class LocaltuyaClimate(LocalTuyaEntity, ClimateEntity):
         """Return the minimum temperature."""
         if self.has_config(CONF_MIN_TEMP_DP):
             return self.dps_conf(CONF_MIN_TEMP_DP)
-        # DEFAULT_MIN_TEMP is in C
-        if self.temperature_unit == UnitOfTemperature.FAHRENHEIT:
-            return DEFAULT_MIN_TEMP * 1.8 + 32
-        else:
-            return DEFAULT_MIN_TEMP
+        return DEFAULT_MIN_TEMP
 
     @property
     def max_temp(self):
         """Return the maximum temperature."""
         if self.has_config(CONF_MAX_TEMP_DP):
             return self.dps_conf(CONF_MAX_TEMP_DP)
-        # DEFAULT_MAX_TEMP is in C
-        if self.temperature_unit == UnitOfTemperature.FAHRENHEIT:
-            return DEFAULT_MAX_TEMP * 1.8 + 32
-        else:
-            return DEFAULT_MAX_TEMP
+        return DEFAULT_MAX_TEMP
 
     def status_updated(self):
         """Device status was updated."""


### PR DESCRIPTION
This fix enables the use of cooling, fan only, and dehumidifying modes as well as the default heating and off modes on tuya air conditioners that support them.

I haven't yet added the current_mode switches for enhanced display with the new climate card but will do so shortly.  I may also modify this to add the mode set as a named option just for the AC unit in question as it has a typo on the tuya API ("dyr" rather than "dry"), and I don't know if this is across all products or just this one.