### PR TITLE
Fix warnings in climate

### DIFF
--- a/custom_components/localtuya/climate.py
+++ b/custom_components/localtuya/climate.py
@@ -181,12 +181,13 @@ class LocaltuyaClimate(LocalTuyaEntity, ClimateEntity):
         self._has_presets = self.has_config(CONF_ECO_DP) or self.has_config(
             CONF_PRESET_DP
         )
+        self._enable_turn_on_off_backwards_compatibility = False
         _LOGGER.debug("Initialized climate [%s]", self.name)
 
     @property
     def supported_features(self):
         """Flag supported features."""
-        supported_features = 0
+        supported_features = ClimateEntityFeature.TURN_OFF | ClimateEntityFeature.TURN_ON
         if self.has_config(CONF_TARGET_TEMPERATURE_DP):
             supported_features = supported_features | ClimateEntityFeature.TARGET_TEMPERATURE
         if self.has_config(CONF_MAX_TEMP_DP):


### PR DESCRIPTION
I'm receiving these warnings on deprecated features in home assistant. Better to fix them before climate breaks completely. The solution is quite simple, after this PR I'm getting zero warnings.


Here's the docs I could find about the problem: https://developers.home-assistant.io/blog/2024/01/24/climate-climateentityfeatures-expanded/
```
2024-03-09 10:34:00.770 WARNING (MainThread) [homeassistant.helpers.entity] Entity None (<class 'custom_components.localtuya.climate.LocaltuyaClimate'>) is using deprecated supported features values which will be removed in HA Core 2025.1. Instead it should use <ClimateEntityFeature.TARGET_TEMPERATURE: 1>, please create a bug report at https://github.com/rospogrigio/localtuya/issues and reference https://developers.home-assistant.io/blog/2023/12/28/support-feature-magic-numbers-deprecation
2024-03-09 10:34:00.770 WARNING (MainThread) [homeassistant.components.climate] Entity None (<class 'custom_components.localtuya.climate.LocaltuyaClimate'>) does not set ClimateEntityFeature.TURN_OFF but implements the turn_off method. Please create a bug report at https://github.com/rospogrigio/localtuya/issues
2024-03-09 10:34:00.771 WARNING (MainThread) [homeassistant.components.climate] Entity None (<class 'custom_components.localtuya.climate.LocaltuyaClimate'>) does not set ClimateEntityFeature.TURN_ON but implements the turn_on method. Please create a bug report at https://github.com/rospogrigio/localtuya/issues
2024-03-09 10:34:00.771 WARNING (MainThread) [homeassistant.components.climate] Entity None (<class 'custom_components.localtuya.climate.LocaltuyaClimate'>) implements HVACMode(s): heat, auto, off and therefore implicitly supports the turn_on/turn_off methods without setting the proper ClimateEntityFeature. Please create a bug report at https://github.com/rospogrigio/localtuya/issues
```