### PR TITLE
Combination of various HVAC PRs

### DIFF
--- a/custom_components/localtuya/climate.py
+++ b/custom_components/localtuya/climate.py
@@ -87,6 +87,9 @@ HVAC_MODE_SETS = {
     "True/False (Heat)": {
         HVACMode.HEAT: True,
     },
+    "True/False (Cool)": {
+        HVACMode.COOL: True,
+    },
     "heat/cool/auto": {
          HVACMode.HEAT: "heat",
          HVACMode.COOL: "cool",
@@ -116,6 +119,10 @@ HVAC_ACTION_SETS = {
     "heating/no_heating": {
         HVACAction.HEATING: "heating",
         HVACAction.IDLE: "no_heating",
+    },
+    "cooling/no_cooling": {
+        HVACAction.COOLING: "cooling",
+        HVACAction.IDLE: "no_cooling",
     },
     "Heat/Warming": {
         HVACAction.HEATING: "Heat",

--- a/custom_components/localtuya/climate.py
+++ b/custom_components/localtuya/climate.py
@@ -64,29 +64,34 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 HVAC_MODE_SETS = {
-    "manual/auto": {
+    "manual/auto (Heat)": {
         HVACMode.HEAT: "manual",
         HVACMode.AUTO: "auto",
     },
-    "Manual/Auto": {
+    "Manual/Auto (Heat)": {
         HVACMode.HEAT: "Manual",
         HVACMode.AUTO: "Auto",
     },
-    "MANUAL/AUTO": {
+    "MANUAL/AUTO (Heat)": {
         HVAC_MODE_HEAT: "MANUAL",
         HVAC_MODE_AUTO: "AUTO",
     },
-    "Manual/Program": {
+    "Manual/Program (Heat)": {
         HVACMode.HEAT: "Manual",
         HVACMode.AUTO: "Program",
     },
-    "m/p": {
+    "m/p (Heat)": {
         HVACMode.HEAT: "m",
         HVACMode.AUTO: "p",
     },
-    "True/False": {
+    "True/False (Heat)": {
         HVACMode.HEAT: True,
     },
+    "heat/cool/auto": {
+         HVACMode.HEAT: "heat",
+         HVACMode.COOL: "cool",
+         HVACMODE.AUTO: "auto",
+     },
     "Auto/Cold/Dry/Wind/Hot": {
         HVACMode.HEAT: "hot",
         HVACMode.FAN_ONLY: "wind",
@@ -94,17 +99,17 @@ HVAC_MODE_SETS = {
         HVACMode.COOL: "cold",
         HVACMode.AUTO: "auto",
     },
-    "1/0": {
+    "1/0 (Heat)": {
         HVACMode.HEAT: "1",
         HVACMode.AUTO: "0",
     },
 }
 HVAC_ACTION_SETS = {
-    "True/False": {
+    "True/False (Heating)": {
         HVACAction.HEATING: True,
         HVACAction.IDLE: False,
     },
-    "open/close": {
+    "open/close (Heating)": {
         HVACAction.HEATING: "open",
         HVACAction.IDLE: "close",
     },
@@ -119,6 +124,10 @@ HVAC_ACTION_SETS = {
     "heating/warming": {
         CURRENT_HVAC_HEAT: "heating",
         CURRENT_HVAC_IDLE: "warming",
+    },
+    "1/0 (Heating)": {
+        HVACAction.HEATING: "1",
+        HVACAction.IDLE: "0",
     },
 }
 HVAC_FAN_MODE_SETS = {
@@ -146,6 +155,11 @@ PRESET_SETS = {
         PRESET_AWAY: "holiday",
         PRESET_HOME: "smart",
         PRESET_NONE: "hold",
+    },
+    "home/leave/auto": {
+        PRESET_AWAY: "leave",
+        PRESET_HOME: "home",
+        PRESET_NONE: "auto",
     },
 }
 


### PR DESCRIPTION
# A quick explanation:
This PR compiles the work of eight different PRs, allowing @rospogrigio to close seven of them in one go.
These are all PRs that allow for the mapping of various found HVAC modes, statuses and presets.

Three of the PRs were found to have already been implemented.

I have not included PRs that contained any changes or additions to logic, with the exception of one, in which I have only included the discovered modes, but not the logic changes suggested, which were good, but require more work before being workable.

I have also taken steps to make it clear when statuses are only applyable to heating or cooling only devices.  For example, "manual vs auto" could apply to cooling or heating devices, but it was not clear that in most cases we were only supporting heating devices.  This should not be more intuitive in the config screen.

## Included changes:
`heat/cool/auto`
With thanks to @Leifex
https://github.com/rospogrigio/localtuya/pull/1517

`home/leave/auto`
With thanks to @fmobile999
https://github.com/rospogrigio/localtuya/pull/1741

`1/0` for current hvac mode
With thanks to @kastmgnru and @Gurutasker
https://github.com/rospogrigio/localtuya/pull/1543
https://github.com/rospogrigio/localtuya/pull/1064

`True/False` and `cooling/no_cooling` for AC options
With thanks to @dubyatp.  I've added these modes, but more work will be needed to use the rest of their cooling work, so I wouldn't recommend closing the following PR just yet.
https://github.com/rospogrigio/localtuya/pull/888

## PRs found to already be implemented:
Thanks to @eturfboer, @jreenen and @bramvandenbussche for these too. It seems they've been implemented since your original PRs came along now.
https://github.com/rospogrigio/localtuya/pull/1351
https://github.com/rospogrigio/localtuya/pull/1352
https://github.com/rospogrigio/localtuya/pull/1684
