### PR TITLE
Add support for the cover that uses zz to open and fz to close

### DIFF
--- a/custom_components/localtuya/cover.py
+++ b/custom_components/localtuya/cover.py
@@ -26,6 +26,7 @@ _LOGGER = logging.getLogger(__name__)
 COVER_ONOFF_CMDS = "on_off_stop"
 COVER_OPENCLOSE_CMDS = "open_close_stop"
 COVER_FZZZ_CMDS = "fz_zz_stop"
+COVER_ZZFZ_CMDS = "zz_fz_stop"
 COVER_12_CMDS = "1_2_3"
 COVER_MODE_NONE = "none"
 COVER_MODE_POSITION = "position"
@@ -41,7 +42,7 @@ def flow_schema(dps):
     """Return schema used in config flow."""
     return {
         vol.Optional(CONF_COMMANDS_SET): vol.In(
-            [COVER_ONOFF_CMDS, COVER_OPENCLOSE_CMDS, COVER_FZZZ_CMDS, COVER_12_CMDS]
+            [COVER_ONOFF_CMDS, COVER_OPENCLOSE_CMDS, COVER_FZZZ_CMDS, COVER_ZZFZ_CMDS, COVER_12_CMDS]
         ),
         vol.Optional(CONF_POSITIONING_MODE, default=DEFAULT_POSITIONING_MODE): vol.In(
             [COVER_MODE_NONE, COVER_MODE_POSITION, COVER_MODE_TIMED]


### PR DESCRIPTION
My motorized cover that is supported by tuya uses 'zz' to open and 'fz' to close unlike the existing available configs. This PR adds support for such devices:

Here is my config:
```
[
    {
        "name": "Shtora",
        "id": "eb3edd413785e7c432tyvj",
        "key": "<key_replaces>",
        "mac": "1c:90:ff:46:a3:2e",
        "uuid": "8a90dbe6926ad3f9",
        "sn": "10009365101364",
        "category": "cl",
        "product_name": "\u7a97\u5e18\u7535\u52a8\u8f68\u9053",
        "product_id": "p1fiefpamvaqek4u",
        "biz_type": 0,
        "model": "BCM700D",
        "sub": false,
        "icon": "https://images.tuyaus.com/smart/icon/ay1529376107687pwiLb/4fcdd29eebd945d6748f7e027ecf2ae3.png",
        "mapping": {
            "101": {
                "code": "position",
                "type": "Integer",
                "values": {
                    "unit": "%",
                    "min": 0,
                    "max": 100,
                    "scale": 0,
                    "step": 1
                }
            },
            "102": {
                "code": "mach_operate",
                "type": "Enum",
                "values": {
                    "range": [
                        "ZZ",
                        "FZ",
                        "STOP"
                    ]
                }
            },
            "103": {
                "code": "opposite",
                "type": "Boolean",
                "values": {}
            }
        },
        "ip": "192.168.50.123",
        "version": "3.3"
    }
]

```