### PR TITLE
Added Work State DP configuration

### DIFF
--- a/custom_components/localtuya/const.py
+++ b/custom_components/localtuya/const.py
@@ -109,6 +109,10 @@ CONF_HVAC_ACTION_SET = "hvac_action_set"
 CONF_ECO_DP = "eco_dp"
 CONF_ECO_VALUE = "eco_value"
 
+#vins customization
+CONF_WORK_STATE_DP = "work_state_dp"
+#vins customization
+
 # vacuum
 CONF_POWERGO_DP = "powergo_dp"
 CONF_IDLE_STATUS_VALUE = "idle_status_value"

--- a/custom_components/localtuya/manifest.json
+++ b/custom_components/localtuya/manifest.json
@@ -10,5 +10,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/rospogrigio/localtuya/issues",
   "requirements": [],
-  "version": "5.2.1"
+  "version": "5.2.2"
 }

--- a/custom_components/localtuya/strings.json
+++ b/custom_components/localtuya/strings.json
@@ -52,6 +52,8 @@
                 "title": "Entity Configuration",
                 "description": "Editing entity with DPS `{id}` and platform `{platform}`.",
                 "data": {
+                    "work_state_dp" : "Work State DP",
+                   
                     "id": "ID",
                     "friendly_name": "Friendly name",
                     "current": "Current",

--- a/custom_components/localtuya/translations/en.json
+++ b/custom_components/localtuya/translations/en.json
@@ -122,6 +122,8 @@
                 "title": "Configure entity",
                 "description": "Please fill out the details for {entity} with type `{platform}`. All settings except for `ID` can be changed from the Options page later.",
                 "data": {
+                    "work_state_dp" : "Work State DP (optional)",
+                    
                     "id": "ID",
                     "friendly_name": "Friendly name",
                     "current": "Current",

--- a/custom_components/localtuya/translations/it.json
+++ b/custom_components/localtuya/translations/it.json
@@ -113,6 +113,8 @@
                 "title": "Configurare entity",
                 "description": "Compila i dettagli per {entity} con tipo `{platform}`.Tutte le impostazioni ad eccezione di `id` possono essere modificate dalla pagina delle opzioni in seguito.",
                 "data": {
+                    "work_state_dp" : "Work State DP (opzionale)",
+ 
                     "id": "ID",
                     "friendly_name": "Nome amichevole",
                     "current": "Corrente",

--- a/custom_components/localtuya/translations/pt-BR.json
+++ b/custom_components/localtuya/translations/pt-BR.json
@@ -113,6 +113,8 @@
                 "title": "Configurar entidade",
                 "description": "Por favor, preencha os detalhes de {entity} com o tipo `{platform}`. Todas as configurações, exceto `ID`, podem ser alteradas na página Opções posteriormente.",
                 "data": {
+                    "work_state_dp" : "Work State DP (optional)",
+                    
                     "id": "ID",
                     "friendly_name": "Nome fantasia",
                     "current": "Atual",


### PR DESCRIPTION
Added optional "Work State DP" for climate entity.
This configuration is useful to avoid usage of heuristic flag if device provide status DP information.
Work State DP configuration takes priority over the heuristic configuration.

Updated wrong version number