### PR TITLE
Update climate.py - remove deprecated constants

### DIFF
--- a/custom_components/localtuya/climate.py
+++ b/custom_components/localtuya/climate.py
@@ -73,8 +73,8 @@ HVAC_MODE_SETS = {
         HVACMode.AUTO: "Auto",
     },
     "MANUAL/AUTO": {
-        HVAC_MODE_HEAT: "MANUAL",
-        HVAC_MODE_AUTO: "AUTO",
+        HVACMode.HEAT: "MANUAL",
+        HVACMode.AUTO: "AUTO",
     },
     "Manual/Program": {
         HVACMode.HEAT: "Manual",
@@ -117,8 +117,8 @@ HVAC_ACTION_SETS = {
         HVACAction.IDLE: "Warming",
     },
     "heating/warming": {
-        CURRENT_HVAC_HEAT: "heating",
-        CURRENT_HVAC_IDLE: "warming",
+        HVACAction.HEATING: "heating",
+        HVACAction.IDLE: "warming",
     },
 }
 HVAC_FAN_MODE_SETS = {


### PR DESCRIPTION
2025.1 removed several deprecated constants, this update will allow the localtuya to load properly post 2025.1