### PR TITLE
Plikc Neve X RF W thermostat fix

### DIFF
--- a/custom_components/localtuya/climate.py
+++ b/custom_components/localtuya/climate.py
@@ -125,6 +125,10 @@ HVAC_ACTION_SETS = {
         HVACAction.HEATING: "heating",
         HVACAction.IDLE: "warming",
     },
+    "heat/off": {
+        HVACAction.HEATING: "heat",
+        HVACAction.IDLE: "off",
+    },
 }
 HVAC_FAN_MODE_SETS = {
     "Auto/Low/Middle/High/Strong": {


### PR DESCRIPTION
Added lines 128, 129, 130, 131 for correct reading of the heating relay dip status with Plikc Neve X RF W thermostat.
![image](https://github.com/user-attachments/assets/ca82a497-e21b-473e-b05e-65c0694e85b1)
