### PR TITLE
Add preset mappings for Comfort/ECO/Antifrost and GH-20E-APP level-ba…

### DIFF
--- a/custom_components/localtuya/climate.py
+++ b/custom_components/localtuya/climate.py
@@ -152,6 +152,19 @@ PRESET_SETS = {
         PRESET_HOME: "smart",
         PRESET_NONE: "hold",
     },
+    "Comfort/ECO/Antifrost": {
+        PRESET_HOME: "Comfort",     # Default comfort mode
+        PRESET_ECO: "ECO",          # Energy-saving mode
+        PRESET_AWAY: "Antifrost",   # Frost protection mode
+    },
+    # GH-20E-APP (Tuya electric heater) – modes: Cool / Low / High
+    # Sends enum values via "level" (DPS 5):
+    # "level_1" = High (Comfort), "level_2" = Low (Eco), "level_3" = Cool (Antifrost)
+    "Cool (level_3) / Low (level_2) / High (level_1)": {
+        PRESET_AWAY: "level_3",   # Cool (Antifrost) – lowest heating level
+        PRESET_ECO:  "level_2",   # Low (Eco) – energy-saving mode
+        PRESET_HOME: "level_1",   # High (Comfort) – maximum heating
+    },
 }
 
 TEMPERATURE_CELSIUS = "celsius"


### PR DESCRIPTION
…sed heaters

This commit adds two new preset mappings to improve compatibility with Tuya-based climate devices:

1. "Comfort/ECO/Antifrost"  
   - For heaters using literal preset values like "Comfort", "ECO", and "Antifrost".
   - Common in many Tuya-powered electric radiators.

2. "Cool (level_3) / Low (level_2) / High (level_1)"  
   - For GH-20E-APP and similar devices that use enum values "level_1", "level_2", and "level_3" (via DPS 5).
   - Provides mapping to:
     - level_1 → PRESET_HOME (High / Comfort)
     - level_2 → PRESET_ECO  (Low / Eco) - level_3 → PRESET_AWAY (Cool / Antifrost)

These additions ensure correct preset behavior in Home Assistant when integrating Tuya-based heaters via localtuya. Tested and validated on real hardware.