### PR TITLE
Deliver matching STATUS responses to the entity listener

### DIFF
--- a/custom_components/localtuya/pytuya/__init__.py
+++ b/custom_components/localtuya/pytuya/__init__.py
@@ -479,6 +479,10 @@ class MessageDispatcher(ContextualLogger):
         """Dispatch a message to someone that is listening."""
         self.debug("Dispatching message CMD %r %s", msg.cmd, msg)
         if msg.seqno in self.listeners:
+            # A status report can also satisfy an outstanding command. Publish
+            # its datapoints before releasing the waiter so entities stay in sync.
+            if msg.cmd == STATUS:
+                self.listener(msg)
             # self.debug("Dispatching sequence number %d", msg.seqno)
             sem = self.listeners[msg.seqno]
             if isinstance(sem, asyncio.Semaphore):

--- a/tests/test_pytuya_dispatcher.py
+++ b/tests/test_pytuya_dispatcher.py
@@ -1,0 +1,89 @@
+"""Regression tests for command responses that also contain a status update."""
+
+import asyncio
+import importlib.util
+from pathlib import Path
+import unittest
+from unittest.mock import Mock
+
+# Load the standalone protocol module without importing the HA integration.
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "custom_components/localtuya/pytuya/__init__.py"
+)
+SPEC = importlib.util.spec_from_file_location("pytuya", MODULE_PATH)
+pytuya = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(pytuya)
+
+
+class MessageDispatcherTests(unittest.IsolatedAsyncioTestCase):
+    """Exercise status delivery independently of response ordering."""
+
+    async def asyncSetUp(self):
+        """Create a dispatcher and an entity status listener."""
+        self.status_listener = Mock()
+        self.dispatcher = pytuya.MessageDispatcher(
+            "test-device", self.status_listener, 3.4, b"0123456789abcdef", False
+        )
+
+    async def start_waiter(self, seqno, command):
+        """Register the response listener before delivering a packet."""
+        waiter = asyncio.create_task(self.dispatcher.wait_for(seqno, command))
+        await asyncio.sleep(0)
+        self.assertIn(seqno, self.dispatcher.listeners)
+        return waiter
+
+    async def test_status_matching_command_updates_listener(self):
+        """A matching STATUS must reach both the entity and command waiter."""
+        waiter = await self.start_waiter(42, pytuya.CONTROL_NEW)
+        status = pytuya.TuyaMessage(42, pytuya.STATUS, 0, b'{"dps":{"1":false}}', 0)
+
+        self.dispatcher._dispatch(status)
+
+        self.status_listener.assert_called_once_with(status)
+        self.assertIs(await waiter, status)
+        self.assertNotIn(42, self.dispatcher.listeners)
+
+    async def test_status_before_ack_is_not_lost(self):
+        """A later ACK must not suppress an earlier matching status report."""
+        waiter = await self.start_waiter(42, pytuya.CONTROL_NEW)
+        status = pytuya.TuyaMessage(42, pytuya.STATUS, 0, b'{"dps":{"1":false}}', 0)
+        ack = pytuya.TuyaMessage(43, pytuya.CONTROL_NEW, 0, b"", 0)
+
+        self.dispatcher._dispatch(status)
+        self.dispatcher._dispatch(ack)
+
+        self.assertIs(await waiter, status)
+        self.status_listener.assert_called_once_with(status)
+
+    async def test_ack_before_status(self):
+        """An ACK may complete the command before an unsolicited status."""
+        waiter = await self.start_waiter(42, pytuya.CONTROL_NEW)
+        ack = pytuya.TuyaMessage(42, pytuya.CONTROL_NEW, 0, b"", 0)
+        status = pytuya.TuyaMessage(43, pytuya.STATUS, 0, b'{"dps":{"1":true}}', 0)
+
+        self.dispatcher._dispatch(ack)
+        self.assertIs(await waiter, ack)
+        self.status_listener.assert_not_called()
+        self.dispatcher._dispatch(status)
+
+        self.status_listener.assert_called_once_with(status)
+
+    async def test_unsolicited_status(self):
+        """Status reports without a pending command still reach the listener."""
+        status = pytuya.TuyaMessage(43, pytuya.STATUS, 0, b'{"dps":{"1":true}}', 0)
+        self.dispatcher._dispatch(status)
+        self.status_listener.assert_called_once_with(status)
+
+    async def test_heartbeat_response(self):
+        """Heartbeat replies still release their special waiter."""
+        seqno = self.dispatcher.HEARTBEAT_SEQNO
+        waiter = await self.start_waiter(seqno, pytuya.HEART_BEAT)
+        heartbeat = pytuya.TuyaMessage(42, pytuya.HEART_BEAT, 0, b"", 0)
+        self.dispatcher._dispatch(heartbeat)
+        self.assertIs(await waiter, heartbeat)
+        self.status_listener.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A switch can report the requested state successfully while its Home Assistant entity keeps the previous state. This happens when a STATUS packet uses the sequence number of an outstanding control command: `MessageDispatcher._dispatch()` delivers it to the command waiter and skips the status listener. The switch service does not consume the returned status, so the entity misses the update.

This change forwards a matching STATUS packet to the status listener before releasing the waiter. ACK handling and unsolicited status delivery keep their existing paths.

## Reproduction

The following packet sequence was observed on a protocol 3.4 switch. Device identifiers, timestamps and encrypted payloads are omitted; this is a condensed trace, not a complete log:

```text
Send CONTROL_NEW: DP 1 = false; wait for sequence N
Receive STATUS: sequence N; decoded DP 1 = false
Receive CONTROL_NEW ACK: sequence N+1; empty payload
```

Before the change, the command waiter received the STATUS packet but the entity listener was not called. The UI briefly showed off and then reverted to on. This differs from the working ordering, where the ACK satisfies the waiter and the subsequent STATUS reaches the listener.

## Validation

- Five dispatcher tests cover a matching STATUS, STATUS before ACK, ACK before STATUS, unsolicited STATUS and heartbeat replies.
- On unmodified upstream commit `59c95cd`, the two matching-STATUS tests fail because the status listener is not called. With the fix, all five pass.
- Tests ran on Python 3.12.3 with cryptography 41.0.7: `python3 -m unittest discover -s tests -v`. The published files were fetched and verified to match the tested files.
- Hardware check: Home Assistant Core 2026.7.1, LocalTuya 5.2.3, one protocol 3.4 switch. Configuration validation passed. After restarting Core, one on/off cycle produced device confirmations with matching entity states. No new command timeout appeared in that short verification window.

The installation also had the `_new_entity_handler` callback fix applied; that separate issue is already covered by #2115 and is not included here. The isolated dispatcher tests reproduce the lost-update bug independently of that callback change.

The hardware check is not a long-term reliability test or validation across other protocol versions. A timeout was also seen before repair, but this change does not add retries or claim to resolve every timeout cause. The full repository tox matrix has not been run.